### PR TITLE
Refactor Dockerfile and enhance OAuth redirect URI handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,94 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build-docker-image:
+      runs-on: ubuntu-latest
+      permissions:
+        contents: read
+        packages: write
+      steps:
+        - name: checkout
+          uses: actions/checkout@v3
+
+        - name: set up qemu
+          uses: docker/setup-qemu-action@v2
+
+        - name: set up buildx
+          uses: docker/setup-buildx-action@v2
+
+        - name: generate image identifier
+          id: image
+          uses: ASzc/change-string-case-action@v5
+          with:
+            string: ${{ github.repository_owner }}
+
+        - name: login to ghcr
+          uses: docker/login-action@v2
+          if: ${{ github.ref == 'refs/heads/main'}}
+          with:
+            registry: ghcr.io
+            username: ${{ github.repository_owner }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+        - name: build web image (production)
+          uses: docker/build-push-action@v3
+          if: ${{ github.ref == 'refs/heads/main'}}
+          with:
+            context: .
+            push: ${{ github.ref == 'refs/heads/main' }}
+            tags: |
+              ghcr.io/${{ steps.image.outputs.lowercase }}/norman-mcp-server:latest
+              ghcr.io/${{ steps.image.outputs.lowercase }}/norman-mcp-server:${{ github.sha }}
+
+            build-args: |
+              RELEASE=${{ github.sha }}
+            cache-from: type=gha
+            cache-to: type=gha,mode=max
+
+  deploy-production:
+    needs: build-docker-image
+    if: github.ref == 'refs/heads/main' && github.repository_owner == 'norman-finance'
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: draft sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          environment: production
+          finalize: false
+
+      - name: read image identifiers
+        id: image
+        uses: ASzc/change-string-case-action@v5
+        with:
+          string: ${{ github.repository_owner }}
+
+      - name: update ai image
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: root
+          key: ${{ secrets.SSH_KEY }}
+          script: docker service update norman_mcp_finance --image ghcr.io/${{ steps.image.outputs.lowercase }}/norman-mcp-server:${{ github.sha }} --with-registry-auth
+
+      - name: finalize sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          environment: production
+          finalize: true

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,64 @@
+# Norman MCP Server Deployment Guide
+
+This document outlines how the Norman MCP Server is deployed using Docker, GitHub Actions, and Ansible.
+
+## Deployment Architecture
+
+The Norman MCP Server is deployed with the following components:
+
+- **Docker**: Container runtime
+- **Traefik**: Reverse proxy and SSL termination
+- **GitHub Actions**: CI/CD pipeline
+- **Ansible**: Configuration management
+
+## Deployment Process
+
+The deployment process is fully automated:
+
+1. Code is pushed to GitHub (master or develop branch)
+2. GitHub Actions workflow builds a Docker image
+3. Docker image is pushed to GitHub Container Registry (ghcr.io)
+4. For production deployments, Ansible is used to:
+   - Pull the latest Docker image
+   - Update the Docker Compose configuration
+   - Deploy the service with Traefik integration
+
+## Manual Deployment
+
+If you need to deploy manually, you can use the Ansible playbook directly:
+
+```bash
+# Clone the devops repository
+git clone https://github.com/norman-finance/norman-devops.git
+cd norman-devops
+
+# Add the vault password file
+echo "your-vault-password" > .vault-key
+
+# Run the playbook
+ansible-playbook -i hosts site.yml --tags mcp-server
+```
+
+## Environment Variables
+
+The main environment variables that control the MCP server:
+
+- `NORMAN_ENVIRONMENT`: Set to "production" for production deployments
+- `NORMAN_TRANSPORT`: Set to "sse" for Server-Sent Events transport
+- `NORMAN_API_BASE_URL`: The Norman API base URL
+- `MCP_SERVER_HOST`: Server host (0.0.0.0 for Docker)
+- `MCP_SERVER_PORT`: Server port (default: 3001)
+
+## OAuth Configuration
+
+For OAuth authentication, you need to configure:
+
+- `NORMAN_OAUTH_CLIENT_ID`: OAuth client ID
+- `NORMAN_OAUTH_CLIENT_SECRET`: OAuth client secret
+- `NORMAN_OAUTH_REDIRECT_URI`: OAuth redirect URI
+
+These values are stored securely in the Ansible vault.
+
+## Monitoring
+
+The MCP server exposes a `/health` endpoint that can be used to monitor the service's health. Traefik is configured to use this endpoint for health checks. 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,36 +2,21 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+# Install dependencies
+RUN pip install --upgrade pip
+
+# Copy project files
+COPY . /app/
+
+# Install the package and additional dependencies
+RUN pip install -e . && \
+    pip install fastapi uvicorn pydantic
+
 # Set environment variables
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    PIP_NO_CACHE_DIR=off \
-    PIP_DISABLE_PIP_VERSION_CHECK=on \
-    PYTHONPATH=/app
+ENV PYTHONUNBUFFERED=1
 
-# Install system dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gcc python3-dev && \
-    rm -rf /var/lib/apt/lists/*
+# Expose server port
+EXPOSE 3001
 
-# Copy all files needed for installation first
-COPY pyproject.toml README.md LICENSE ./
-
-# Copy the code
-COPY norman_mcp ./norman_mcp
-
-# First try to install in development mode
-RUN pip install -e . || \
-    # If that fails, install dependencies manually and ensure scripts are available
-    (pip install requests>=2.25.0 python-dotenv>=0.19.0 pyyaml>=6.0 mcp>=0.3.0 "mcp[cli]>=1.3.0" && \
-     pip install -e .)
-
-# Ensure norman-mcp command is available as fallback
-RUN ln -sf /app/norman_mcp/cli.py /usr/local/bin/norman-mcp && \
-    chmod +x /usr/local/bin/norman-mcp
-
-# Ensure proper permissions
-RUN chmod -R 755 /app
-
-# Run the application via Python module as a more reliable approach
-CMD ["python", "-m", "norman_mcp"]
+# Run the server
+CMD ["python", "-m", "norman_mcp", "--transport", "sse", "--environment", "production"]

--- a/norman_mcp/server.py
+++ b/norman_mcp/server.py
@@ -2,6 +2,7 @@ import os
 import logging
 from typing import Any, Dict
 from contextlib import asynccontextmanager
+import time
 
 from pydantic import AnyHttpUrl
 from dotenv import load_dotenv


### PR DESCRIPTION
- Simplified Dockerfile by removing unnecessary steps and consolidating installation commands.
- Added environment variable for Python unbuffered output and exposed server port 3001.
- Updated server command to run with specific transport and environment settings.
- Implemented a monkey patch in provider.py to allow dynamic redirect URIs for OAuth, enhancing flexibility for local development and specific web applications.