### PR TITLE
Update CI workflow to rename deployment step for MCP server image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,13 +75,13 @@ jobs:
         with:
           string: ${{ github.repository_owner }}
 
-      - name: update ai image
+      - name: update mcp server image
         uses: appleboy/ssh-action@v0.1.7
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: root
           key: ${{ secrets.SSH_KEY }}
-          script: docker service update norman_mcp --image ghcr.io/${{ steps.image.outputs.lowercase }}/norman-mcp-server:${{ github.sha }} --with-registry-auth
+          script: docker service update norman_mcp_server --image ghcr.io/${{ steps.image.outputs.lowercase }}/norman-mcp-server:${{ github.sha }} --with-registry-auth
 
       - name: finalize sentry release
         uses: getsentry/action-release@v1


### PR DESCRIPTION
- Changed the step name from "update ai image" to "update mcp server image" for clarity.
- Updated the Docker service name in the deployment script from `norman_mcp` to `norman_mcp_server` to ensure accurate service reference during deployment.