### PR TITLE
Update CI workflow to correct Docker service name in deployment script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST }}
           username: root
           key: ${{ secrets.SSH_KEY }}
-          script: docker service update norman_mcp_server --image ghcr.io/${{ steps.image.outputs.lowercase }}/norman-mcp-server:${{ github.sha }} --with-registry-auth
+          script: docker service update norman_mcp --image ghcr.io/${{ steps.image.outputs.lowercase }}/norman-mcp-server:${{ github.sha }} --with-registry-auth
 
       - name: finalize sentry release
         uses: getsentry/action-release@v1


### PR DESCRIPTION
- Changed the Docker service name in the deployment script from `norman_mcp_server` to `norman_mcp` for consistency with previous updates.