### PR TITLE
Add new allowed redirect URI for MCP finance in provider.py

### DIFF
--- a/norman_mcp/auth/provider.py
+++ b/norman_mcp/auth/provider.py
@@ -37,6 +37,7 @@ ALLOWED_REDIRECT_HOSTS = [
     "https://claude.ai",  # Claude.ai web app
     "https://claude-api",  # Claude API client
     "http://0.0.0.0:",    # Any local interface with any port
+    "https://mcp.norman.finance",
 ]
 
 def patched_validate_redirect_uri(self, redirect_uri: Optional[AnyHttpUrl]) -> AnyHttpUrl:


### PR DESCRIPTION
- Included "https://mcp.norman.finance" in the ALLOWED_REDIRECT_HOSTS list to support additional OAuth redirect functionality.