### PR TITLE
Refine server command in Dockerfile by removing host and port parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ ENV PYTHONUNBUFFERED=1
 EXPOSE 3001
 
 # Run the server
-CMD ["python", "-m", "norman_mcp", "--transport", "sse", "--environment", "production", "--host", "mcp.norman.finance", "--port", "3001", "--public-url", "https://mcp.norman.finance"]
+CMD ["python", "-m", "norman_mcp", "--transport", "sse", "--environment", "production", "--public-url", "https://mcp.norman.finance"]


### PR DESCRIPTION
- Updated the CMD instruction in the Dockerfile to simplify the server command by removing the host and port arguments, maintaining the public URL for deployment.