### PR TITLE
Refine server command in Dockerfile by removing public URL parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ ENV PYTHONUNBUFFERED=1
 EXPOSE 3001
 
 # Run the server
-CMD ["python", "-m", "norman_mcp", "--transport", "sse", "--environment", "production", "--public-url", "https://mcp.norman.finance"]
+CMD ["python", "-m", "norman_mcp", "--transport", "sse", "--environment", "production"]


### PR DESCRIPTION
- Updated the CMD instruction in the Dockerfile to simplify the server command by removing the public URL argument, while retaining the transport and environment settings for production.