### PR TITLE
WI:

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,15 +155,19 @@ Follow the instructions here: [Installing uv](https://docs.astral.sh/uv/getting-
 
 ### Authentication Methods
 
-The Norman MCP server supports two authentication methods:
+The Norman MCP server supports three authentication methods:
 
-#### 1. OAuth Authentication (for SSE transport)
+#### 1. OAuth Authentication (for SSE and StreamableHTTP transports)
 
-When using the server with MCP Inspector, Claude, or other SSE clients, the server uses OAuth 2.0 authentication:
+When using the server with MCP Inspector, Claude, or other clients that support OAuth, the server uses OAuth 2.0 authentication:
 
-1. Start the server with SSE transport:
+1. Start the server with the appropriate transport:
    ```bash
+   # For SSE transport
    python -m norman_mcp --transport sse
+   
+   # For StreamableHTTP transport
+   python -m norman_mcp --transport streamable-http
    ```
 
 2. When connecting to the server, you'll be directed to a login page

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "mcp>=0.3.0",
-    "mcp[cli]>=1.7.0",
-    "mcp[sse]>=1.7.0",
+    "mcp[cli]>=1.8.0",
+    "mcp[sse]>=1.8.0",
     "requests>=2.25.0",
     "python-dotenv>=0.19.0",
     "pyyaml>=6.0.1",

--- a/remote-hosting.md
+++ b/remote-hosting.md
@@ -10,6 +10,41 @@ The server now reads these environment variables for configuration:
 - `NORMAN_MCP_PORT`: The port to bind to (default: 3001)
 - `NORMAN_MCP_PUBLIC_URL`: The public URL where the server can be accessed (default: "http://{HOST}:{PORT}")
 
+## Transport Options
+
+The Norman MCP server supports three different transport protocols:
+
+### SSE (Server-Sent Events)
+
+The default transport method, best for web-based clients:
+
+```bash
+python -m norman_mcp --transport sse
+```
+
+### StreamableHTTP
+
+A newer transport method that offers better performance and flexibility:
+
+```bash
+# Run with default options (stateful mode with SSE responses)
+python -m norman_mcp --transport streamable_http
+
+# Run in stateless mode (no session tracking)
+python -m norman_mcp --transport streamable_http --stateless
+
+# Use JSON responses instead of SSE streams
+python -m norman_mcp --transport streamable_http --json-response
+```
+
+### stdio (Standard Input/Output)
+
+For command-line tools or local use, requires credentials in environment variables:
+
+```bash
+python -m norman_mcp --transport stdio
+```
+
 ## Remote Hosting Setup
 
 ### 1. Server Configuration
@@ -29,7 +64,11 @@ export NORMAN_MCP_PUBLIC_URL="http://203.0.113.1:3001"
 2. Launch the server with the appropriate parameters:
 
 ```bash
-python -m norman_mcp.server --transport sse --public-url "https://norman-mcp.example.com"
+# For SSE transport
+python -m norman_mcp --transport sse --public-url "https://norman-mcp.example.com"
+
+# For StreamableHTTP transport
+python -m norman_mcp --transport streamable_http --public-url "https://norman-mcp.example.com"
 ```
 
 ### 2. Using with MCP Inspector or Claude Desktop
@@ -58,8 +97,8 @@ For development, you can use tools like ngrok to make your localhost accessible 
 # Install ngrok
 npm install -g ngrok
 
-# Start Norman MCP server
-python -m norman_mcp.server --transport sse
+# Start Norman MCP server (with your preferred transport)
+python -m norman_mcp --transport streamable_http
 
 # In another terminal, create a tunnel
 ngrok http 3001
@@ -67,16 +106,23 @@ ngrok http 3001
 
 Then use the ngrok URL (e.g., https://abcd1234.ngrok.io) as your `NORMAN_MCP_PUBLIC_URL`.
 
+## Streamable HTTP vs SSE
+
+When deciding which transport to use, consider these factors:
+
+1. **Compatibility**: SSE has wider client compatibility, while StreamableHTTP is newer but more flexible.
+2. **Performance**: StreamableHTTP can offer better performance for high-traffic scenarios.
+3. **Features**:
+   - **Stateless Mode**: StreamableHTTP can operate in stateless mode, which is useful for serverless environments.
+   - **JSON Responses**: StreamableHTTP can return JSON responses instead of SSE streams, which may be easier to process for some clients.
+
+For most use cases, either transport will work well. The StreamableHTTP transport provides backward compatibility with SSE clients.
+
 ## Troubleshooting
 
-### CORS Issues
+If you experience issues with remote hosting:
 
-If you experience CORS issues, make sure your public URL is properly configured and that clients are using the correct URL.
-
-### OAuth Failures
-
-If OAuth authentication fails:
-
-1. Check that your redirect URIs are being accepted
-2. Verify that you're using the correct public URL
-3. Make sure the Norman API token is being correctly obtained and stored 
+1. Check your firewall settings to ensure the server port is open
+2. Verify that your `NORMAN_MCP_PUBLIC_URL` is correctly set and accessible
+3. For SSL/TLS issues, ensure your certificates are valid
+4. Check the server logs for any error messages 

--- a/test_client/streamable_http_client.py
+++ b/test_client/streamable_http_client.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+"""
+Test client for the Norman MCP Server with Streamable HTTP transport.
+
+This script connects to the Norman MCP server using the Streamable HTTP transport
+and tests basic functionality by listing available tools.
+"""
+
+import asyncio
+import logging
+import sys
+from datetime import timedelta
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)]
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def main():
+    """Connect to the Norman MCP server and test basic functionality."""
+    # Default server URL - can be overridden with a command line argument
+    server_url = "http://localhost:3001"
+    if len(sys.argv) > 1:
+        server_url = sys.argv[1]
+
+    logger.info(f"Connecting to Norman MCP server at {server_url}")
+    logger.info(f"Using Streamable HTTP transport (compatible with the server's streamable-http transport)")
+
+    # Connect to the Streamable HTTP server with a longer timeout for debugging
+    try:
+        async with streamablehttp_client(
+            server_url,
+            timeout=timedelta(seconds=30),
+            sse_read_timeout=timedelta(seconds=300),
+        ) as (read_stream, write_stream, get_session_id):
+            logger.info("Connected to server, initializing session...")
+
+            # Create a client session
+            async with ClientSession(read_stream, write_stream) as session:
+                # Initialize the connection
+                await session.initialize()
+                logger.info("Session initialized")
+                
+                # Get the session ID
+                session_id = get_session_id()
+                logger.info(f"Session ID: {session_id}")
+
+                # List available prompts
+                try:
+                    logger.info("Listing available prompts...")
+                    prompts = await session.list_prompts()
+                    logger.info(f"Available prompts: {[p.name for p in prompts]}")
+                except Exception as e:
+                    logger.error(f"Error listing prompts: {e}")
+
+                # List available tools
+                try:
+                    logger.info("Listing available tools...")
+                    tools = await session.list_tools()
+                    logger.info(f"Available tools: {[t.name for t in tools]}")
+                except Exception as e:
+                    logger.error(f"Error listing tools: {e}")
+
+                # List available resources
+                try:
+                    logger.info("Listing available resources...")
+                    resources = await session.list_resources()
+                    logger.info(f"Available resources: {resources}")
+                except Exception as e:
+                    logger.error(f"Error listing resources: {e}")
+
+                # Call a simple tool if available
+                try:
+                    logger.info("Calling list_clients tool...")
+                    result = await session.call_tool("list_clients", {})
+                    logger.info(f"Tool result: {result}")
+                except Exception as e:
+                    logger.error(f"Error calling tool: {e}")
+
+    except Exception as e:
+        logger.error(f"Connection error: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    asyncio.run(main()) 

--- a/tools/run.sh
+++ b/tools/run.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+
+# Run Norman MCP Server with different transport options
+# This script sets up a Norman MCP server with the specified transport
+
+# Check if .env file exists and source it if it does
+if [ -f .env ]; then
+    source .env
+fi
+
+# Default values
+HOST="0.0.0.0"
+PORT=3001
+PUBLIC_URL=""
+TRANSPORT="sse"
+DEBUG=false
+EMAIL=""
+PASSWORD=""
+ENVIRONMENT="production"
+STATELESS=false
+JSON_RESPONSE=false
+
+# Usage information
+usage() {
+    echo "Usage: $0 [options]"
+    echo "Options:"
+    echo "  --transport TRANSPORT    Transport protocol to use (sse, stdio, streamable-http)"
+    echo "  --host HOST              Host to bind to"
+    echo "  --port PORT              Port to bind to"
+    echo "  --public-url URL         Public URL for OAuth callbacks"
+    echo "  --debug                  Enable debug logging"
+    echo "  --email EMAIL            Norman Finance account email"
+    echo "  --password PASSWORD      Norman Finance account password"
+    echo "  --environment ENV        API environment (production or sandbox)"
+    echo "  --stateless              Run streamable-http transport in stateless mode"
+    echo "  --json-response          Use JSON responses for streamable-http transport"
+    echo "  --help                   Show this help message"
+    exit 1
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --help)
+      usage
+      ;;
+    --transport)
+      TRANSPORT="$2"
+      shift 2
+      ;;
+    --host)
+      HOST="$2"
+      shift 2
+      ;;
+    --port)
+      PORT="$2"
+      shift 2
+      ;;
+    --public-url)
+      PUBLIC_URL="$2"
+      shift 2
+      ;;
+    --debug)
+      DEBUG=true
+      shift
+      ;;
+    --email)
+      EMAIL="$2"
+      shift 2
+      ;;
+    --password)
+      PASSWORD="$2"
+      shift 2
+      ;;
+    --environment)
+      ENVIRONMENT="$2"
+      shift 2
+      ;;
+    --stateless)
+      STATELESS=true
+      shift
+      ;;
+    --json-response)
+      JSON_RESPONSE=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      usage
+      ;;
+  esac
+done
+
+# Validate transport option
+if [[ "$TRANSPORT" != "sse" && "$TRANSPORT" != "stdio" && "$TRANSPORT" != "streamable-http" ]]; then
+  echo "Error: Invalid transport option. Must be 'sse', 'stdio', or 'streamable-http'."
+  usage
+fi
+
+# If public URL is not set, generate it based on host and port
+if [ -z "$PUBLIC_URL" ]; then
+  PUBLIC_URL="http://${HOST}:${PORT}"
+fi
+
+# Build the command arguments
+ARGS=("--host" "$HOST" "--port" "$PORT" "--public-url" "$PUBLIC_URL" "--transport" "$TRANSPORT")
+
+# Add optional arguments
+if [ "$DEBUG" = true ]; then
+  ARGS+=("--debug")
+fi
+
+if [ ! -z "$EMAIL" ]; then
+  ARGS+=("--email" "$EMAIL")
+fi
+
+if [ ! -z "$PASSWORD" ]; then
+  ARGS+=("--password" "$PASSWORD")
+fi
+
+if [ ! -z "$ENVIRONMENT" ]; then
+  ARGS+=("--environment" "$ENVIRONMENT")
+fi
+
+# Add streamable-http-specific options
+if [ "$TRANSPORT" = "streamable-http" ]; then
+  if [ "$STATELESS" = true ]; then
+    ARGS+=("--stateless")
+  fi
+  
+  if [ "$JSON_RESPONSE" = true ]; then
+    ARGS+=("--json-response")
+  fi
+fi
+
+# Print server information
+echo "Starting Norman MCP Server"
+echo "Transport: $TRANSPORT"
+echo "Host: $HOST"
+echo "Port: $PORT"
+echo "Public URL: $PUBLIC_URL"
+
+if [ "$TRANSPORT" = "streamable-http" ]; then
+  if [ "$STATELESS" = true ]; then
+    echo "Mode: Stateless (no session tracking)"
+  else
+    echo "Mode: Stateful (with session tracking)"
+  fi
+
+  if [ "$JSON_RESPONSE" = true ]; then
+    echo "Response format: JSON"
+  else
+    echo "Response format: SSE streams"
+  fi
+fi
+
+if [ ! -z "$EMAIL" ]; then
+  echo "Using credentials for: $EMAIL"
+fi
+
+echo "Environment: $ENVIRONMENT"
+echo ""
+
+echo "Starting server with: python -m norman_mcp ${ARGS[@]}"
+echo ""
+
+# Start the server
+python -m norman_mcp "${ARGS[@]}" 

--- a/tools/run_streamable_http.sh
+++ b/tools/run_streamable_http.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+# Run Norman MCP Server with Streamable HTTP transport
+# This script sets the necessary environment variables for authentication and starts the server
+
+# Check if .env file exists and source it if it does
+if [ -f .env ]; then
+    source .env
+fi
+
+# Default values
+HOST="0.0.0.0"
+PORT=3001
+PUBLIC_URL=""
+STATELESS=false
+JSON_RESPONSE=false
+DEBUG=false
+EMAIL=""
+PASSWORD=""
+ENVIRONMENT="production"
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --host)
+      HOST="$2"
+      shift 2
+      ;;
+    --port)
+      PORT="$2"
+      shift 2
+      ;;
+    --public-url)
+      PUBLIC_URL="$2"
+      shift 2
+      ;;
+    --stateless)
+      STATELESS=true
+      shift
+      ;;
+    --json-response)
+      JSON_RESPONSE=true
+      shift
+      ;;
+    --debug)
+      DEBUG=true
+      shift
+      ;;
+    --email)
+      EMAIL="$2"
+      shift 2
+      ;;
+    --password)
+      PASSWORD="$2"
+      shift 2
+      ;;
+    --environment)
+      ENVIRONMENT="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# If public URL is not set, generate it
+if [ -z "$PUBLIC_URL" ]; then
+  PUBLIC_URL="http://${HOST}:${PORT}"
+fi
+
+# Build the command arguments
+ARGS=("--host" "$HOST" "--port" "$PORT" "--public-url" "$PUBLIC_URL" "--transport" "streamable-http")
+
+# Add optional arguments
+if [ "$STATELESS" = true ]; then
+  ARGS+=("--stateless")
+fi
+
+if [ "$JSON_RESPONSE" = true ]; then
+  ARGS+=("--json-response")
+fi
+
+if [ "$DEBUG" = true ]; then
+  ARGS+=("--debug")
+fi
+
+if [ ! -z "$EMAIL" ]; then
+  ARGS+=("--email" "$EMAIL")
+fi
+
+if [ ! -z "$PASSWORD" ]; then
+  ARGS+=("--password" "$PASSWORD")
+fi
+
+if [ ! -z "$ENVIRONMENT" ]; then
+  ARGS+=("--environment" "$ENVIRONMENT")
+fi
+
+# Print server information
+echo "Starting Norman MCP Server with Streamable HTTP transport"
+echo "Host: $HOST"
+echo "Port: $PORT"
+echo "Public URL: $PUBLIC_URL"
+
+if [ "$STATELESS" = true ]; then
+  echo "Mode: Stateless (no session tracking)"
+else
+  echo "Mode: Stateful (with session tracking)"
+fi
+
+if [ "$JSON_RESPONSE" = true ]; then
+  echo "Response format: JSON"
+else
+  echo "Response format: SSE streams"
+fi
+
+if [ ! -z "$EMAIL" ]; then
+  echo "Using credentials for: $EMAIL"
+fi
+
+echo "Environment: $ENVIRONMENT"
+echo ""
+
+echo "Starting server with: python -m norman_mcp ${ARGS[@]}"
+echo ""
+
+# Start the server
+python -m norman_mcp "${ARGS[@]}" 


### PR DESCRIPTION
Update transport options and enhance documentation

- Updated the `pyproject.toml` to require `mcp[cli]` and `mcp[sse]` version 1.8.0.
- Expanded the README.md to include details on three authentication methods and transport options, specifically for StreamableHTTP.
- Enhanced the remote-hosting.md with new transport options and troubleshooting tips.
- Modified cli.py to support new transport options and added flags for stateless mode and JSON responses.
- Updated server.py to handle StreamableHTTP transport and its configuration options.