### PR TITLE
fix: OAuth token refresh + OpenAI client_id fallback

### DIFF
--- a/norman_mcp/api/client.py
+++ b/norman_mcp/api/client.py
@@ -273,10 +273,37 @@ class NormanAPI:
         except requests.exceptions.HTTPError as e:
             # Handle token expiration
             if e.response.status_code == 401:
-                logger.info("Token expired, refreshing...")
-                self.authenticate()
-                # Retry the request once
-                return self._make_request(method, url, params, json_data, files)
+                if self.token_source == "env":
+                    logger.info("Env token expired, re-authenticating...")
+                    try:
+                        self.authenticate()
+                    except Exception as auth_err:
+                        logger.error(f"Re-auth failed: {auth_err}")
+                        return {
+                            "error": "Authentication failed. Check NORMAN_EMAIL/NORMAN_PASSWORD.",
+                            "status_code": 401,
+                        }
+                    return self._make_request(method, url, params, json_data, files)
+
+                # OAuth mode: try to refresh the Norman token transparently
+                # using the refresh token we stored at code-exchange time.
+                new_norman_token = self._refresh_oauth_norman_token()
+                if new_norman_token:
+                    self.access_token = new_norman_token
+                    self.token_source = "global"
+                    return self._make_request(method, url, params, json_data, files)
+
+                logger.warning("Cannot refresh Norman token; client must reconnect")
+                self.access_token = None
+                from norman_mcp.context import set_api_token
+                set_api_token(None)
+                return {
+                    "error": (
+                        "Your Norman session expired. Please disconnect and reconnect "
+                        "the Norman connector in your AI client to re-authenticate."
+                    ),
+                    "status_code": 401,
+                }
             elif e.response.status_code == 403:
                 logger.error("Access forbidden. Check your account permissions.")
                 return {"error": "Access forbidden. Check your account permissions.", "status_code": 403}
@@ -312,7 +339,33 @@ class NormanAPI:
             logger.error(f"Unexpected error making request to {url}: {str(e)}")
             return {"error": f"Unexpected error: {str(e)}"}
 
+    def _refresh_oauth_norman_token(self) -> Optional[str]:
+        """Refresh the Norman access token for the current MCP request (OAuth).
+
+        Returns the new Norman access token or None if refresh isn't possible.
+        Also updates the global `_api_token` so subsequent requests in this
+        session see the new token.
+        """
+        try:
+            from norman_mcp.context import get_oauth_provider, set_api_token
+            provider = get_oauth_provider()
+            if provider is None:
+                return None
+
+            access_token = get_access_token()
+            mcp_token = access_token.token if access_token else None
+            if not mcp_token:
+                return None
+
+            new_norman_token = provider.refresh_norman_token_sync(mcp_token)
+            if new_norman_token:
+                set_api_token(new_norman_token)
+            return new_norman_token
+        except Exception as e:
+            logger.error(f"Transparent Norman refresh failed: {e}")
+            return None
+
     def set_company(self, company_id: str) -> None:
         """Manually set a company ID for this API client."""
         logger.info(f"Manually setting company ID to: {company_id}")
-        self.company_id = company_id 
+        self.company_id = company_id

--- a/norman_mcp/auth/provider.py
+++ b/norman_mcp/auth/provider.py
@@ -476,7 +476,7 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
         # Check for refresh token
         norman_refresh = self.token_mapping.get(f"refresh_{authorization_code.code}")
         refresh_token_id = None
-        
+
         if norman_refresh:
             refresh_token_id = f"mcp_refresh_{secrets.token_hex(16)}"
             self.refresh_tokens[refresh_token_id] = RefreshToken(
@@ -486,6 +486,10 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
                 expires_at=int(time.time()) + 30 * 86400,  # 30 days
             )
             self.token_mapping[refresh_token_id] = norman_refresh
+            # Also index by access token so we can transparently refresh the
+            # Norman access token when it expires mid-session (see
+            # NormanAPI._make_request 401 handler).
+            self.token_mapping[f"refresh_for_{mcp_token}"] = norman_refresh
         
         # Clean up used authorization code
         del self.auth_codes[authorization_code.code]
@@ -585,10 +589,13 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
                 )
                 
                 self.token_mapping[new_mcp_token] = new_norman_token
-                
+
                 # Update refresh token if new one provided
                 if new_norman_refresh:
                     self.token_mapping[refresh_token.token] = new_norman_refresh
+                self.token_mapping[f"refresh_for_{new_mcp_token}"] = (
+                    new_norman_refresh or self.token_mapping.get(refresh_token.token)
+                )
                 
                 logger.info(f"✅ Refreshed MCP token: {new_mcp_token[:15]}...")
                 self._save_state()
@@ -626,3 +633,58 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
     def get_norman_token(self, mcp_token: str) -> Optional[str]:
         """Get the Norman API token for a given MCP token."""
         return self.token_mapping.get(mcp_token)
+
+    def refresh_norman_token_sync(self, mcp_token: str) -> Optional[str]:
+        """Refresh the Norman access token for an MCP access token (sync).
+
+        Called from NormanAPI._make_request (which uses `requests`) when
+        Norman returns 401 mid-session: we swap in a fresh Norman access
+        token so the MCP client does not need to reconnect. Returns the
+        new Norman access token, or None if refresh is impossible
+        (no stored refresh token, or refresh call failed).
+        """
+        import requests as _requests
+
+        norman_refresh = self.token_mapping.get(f"refresh_for_{mcp_token}")
+        if not norman_refresh:
+            logger.warning("No Norman refresh token stored for mcp_token %s...", mcp_token[:12])
+            return None
+
+        token_payload = {
+            "grant_type": "refresh_token",
+            "refresh_token": norman_refresh,
+            "client_id": get_norman_oauth_client_id(),
+        }
+        client_secret = get_norman_oauth_client_secret()
+        if client_secret:
+            token_payload["client_secret"] = client_secret
+
+        try:
+            response = _requests.post(
+                self.norman_token_url,
+                data=token_payload,
+                timeout=config.NORMAN_API_TIMEOUT,
+            )
+        except _requests.exceptions.RequestException as e:
+            logger.error("Network error during Norman refresh: %s", e)
+            return None
+
+        if response.status_code != 200:
+            logger.error(
+                "Norman refresh failed for mcp_token %s...: %s",
+                mcp_token[:12], response.status_code,
+            )
+            return None
+
+        data = response.json()
+        new_norman_token = data.get("access_token")
+        new_norman_refresh = data.get("refresh_token")
+        if not new_norman_token:
+            return None
+
+        self.token_mapping[mcp_token] = new_norman_token
+        if new_norman_refresh:
+            self.token_mapping[f"refresh_for_{mcp_token}"] = new_norman_refresh
+        self._save_state()
+        logger.info("✅ Refreshed Norman token for mcp_token %s...", mcp_token[:12])
+        return new_norman_token

--- a/norman_mcp/context.py
+++ b/norman_mcp/context.py
@@ -6,8 +6,18 @@ from mcp.server.fastmcp import Context
 
 """Context variables for the Norman MCP server."""
 
-# Global variable to store the OAuth provider across modules
-oauth_provider = None 
+# Global variable to store the OAuth provider across modules.
+# Set by server.create_app after the provider is constructed.
+oauth_provider = None
+
+def set_oauth_provider(provider):
+    """Set the global OAuth provider reference."""
+    global oauth_provider
+    oauth_provider = provider
+
+def get_oauth_provider():
+    """Get the global OAuth provider reference (may be None before startup)."""
+    return oauth_provider
 
 # Global variable to store the API client
 _api_client = None

--- a/norman_mcp/server.py
+++ b/norman_mcp/server.py
@@ -121,9 +121,19 @@ from mcp.server.auth.middleware.client_auth import ClientAuthenticator, Authenti
 _original_authenticate_request = ClientAuthenticator.authenticate_request
 
 async def _patched_authenticate_request(self, request):
-    """Extract client_id from Basic Auth header if not in form body."""
+    """Recover client_id when the client omits it from the POST body.
+
+    OpenAI's Apps platform (platform.openai.com/apps-manage) and some ChatGPT
+    connector flows POST to /token with only `code`/`refresh_token` + PKCE and
+    do not include `client_id` anywhere — violating RFC 6749 but widespread
+    enough to need a workaround. We fall back in this order:
+      1. Basic Auth header (n8n and similar)
+      2. Look up the stored authorization_code or refresh_token — each is
+         bound to a single client_id at issue time, so this is safe.
+    """
     form_data = await request.form()
     client_id = form_data.get("client_id")
+    client_secret_from_basic = None
 
     if not client_id:
         auth_header = request.headers.get("Authorization", "")
@@ -132,19 +142,33 @@ async def _patched_authenticate_request(self, request):
                 decoded = _b64.b64decode(auth_header[6:]).decode("utf-8")
                 if ":" in decoded:
                     basic_client_id, basic_client_secret = decoded.split(":", 1)
-                    basic_client_id = _unquote(basic_client_id)
-                    basic_client_secret = _unquote(basic_client_secret)
-
-                    mutable = dict(form_data.multi_items())
-                    mutable_dict = dict(mutable)
-                    mutable_dict["client_id"] = basic_client_id
-                    if basic_client_secret:
-                        mutable_dict["client_secret"] = basic_client_secret
-
-                    patched_form = _FormData(mutable_dict)
-                    request._form = patched_form
+                    client_id = _unquote(basic_client_id)
+                    client_secret_from_basic = _unquote(basic_client_secret) or None
             except Exception:
                 pass
+
+    if not client_id:
+        grant_type = form_data.get("grant_type")
+        provider = getattr(self, "provider", None)
+        if grant_type == "authorization_code":
+            code = form_data.get("code")
+            auth_codes = getattr(provider, "auth_codes", None) or {}
+            auth_code = auth_codes.get(str(code)) if code else None
+            if auth_code is not None:
+                client_id = auth_code.client_id
+        elif grant_type == "refresh_token":
+            rt = form_data.get("refresh_token")
+            refresh_tokens = getattr(provider, "refresh_tokens", None) or {}
+            refresh = refresh_tokens.get(str(rt)) if rt else None
+            if refresh is not None:
+                client_id = refresh.client_id
+
+    if client_id and form_data.get("client_id") != client_id:
+        mutable_dict = dict(form_data.multi_items())
+        mutable_dict["client_id"] = client_id
+        if client_secret_from_basic and not mutable_dict.get("client_secret"):
+            mutable_dict["client_secret"] = client_secret_from_basic
+        request._form = _FormData(mutable_dict)
 
     return await _original_authenticate_request(self, request)
 
@@ -250,7 +274,9 @@ def create_app(host=None, port=None, public_url=None, transport="sse", streamabl
     if use_oauth:
         server_url = AnyHttpUrl(public_url)
         oauth_provider = NormanOAuthProvider(server_url=server_url)
-        
+        from norman_mcp.context import set_oauth_provider
+        set_oauth_provider(oauth_provider)
+
         from norman_mcp.auth.provider import SUPPORTED_SCOPES
         auth_settings = AuthSettings(
             issuer_url=server_url,


### PR DESCRIPTION
## Summary
Two independent OAuth fixes surfaced by real integrations:

- **Transparent Norman token refresh on 401.** Norman access tokens expire (~10h) before MCP access tokens (24h). Previously, `NormanAPI._make_request` called `self.authenticate()` (env-only) on 401 → raised `ValueError("Norman Finance credentials not set...")` uncaught → users saw that misleading text in Claude/ChatGPT. Now we index `token_mapping[f"refresh_for_{mcp_token}"] = norman_refresh` at code-exchange time and call `NormanOAuthProvider.refresh_norman_token_sync` on 401 to swap in a fresh Norman access token transparently. If refresh can't happen, return a clear "reconnect the connector" error instead of crashing.
- **OpenAI Apps platform /token fallback.** OpenAI's Apps platform POSTs `/token` without `client_id` in body or Basic Auth (known OpenAI bug, see [community thread](https://community.openai.com/t/mcp-connector-token-request-lacks-mandatory-client-id-field/1366347) and [python-sdk #1521](https://github.com/modelcontextprotocol/python-sdk/issues/1521)), which made the SDK's `ClientAuthenticator` return 401 "Missing client_id". Extended the existing `_patched_authenticate_request` to fall back to the `client_id` stored on the authorization code or refresh token — safe because each code/refresh is bound to exactly one client at issue time.

Existing sessions issued before this change don't have the `refresh_for_{mcp_token}` mapping, so they'll hit the "reconnect the connector" error once. After reconnecting, transparent refresh takes over.

## Test plan
- [x] Smoke tests for the `ClientAuthenticator` patch: body client_id, Basic Auth, auth_code fallback, unknown code rejection.
- [x] Smoke tests for `refresh_norman_token_sync`: missing mapping → None; Norman rejects bogus refresh → None.
- [ ] After deploy: verify a new OAuth flow through Claude — disconnect & reconnect the connector, then call a tool after 10h+ to confirm the refresh happens silently.
- [ ] Retry the OpenAI Apps submission at https://platform.openai.com/apps-manage — the OAuth step should complete without the 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)