### PR TITLE
fix: isolate Norman token and company id per request via ContextVars

### DIFF
--- a/norman_mcp/api/client.py
+++ b/norman_mcp/api/client.py
@@ -1,230 +1,300 @@
 import logging
 import requests
-from dataclasses import dataclass
 from typing import Any, Dict, Optional
 from urllib.parse import urljoin
 
 from ..config.settings import config
 from ..security.utils import validate_input, validate_url
 from mcp.server.auth.middleware.auth_context import get_access_token
-from norman_mcp.context import oauth_provider
+from norman_mcp.context import (
+    get_api_company_id,
+    get_api_token,
+    get_api_token_source,
+    get_oauth_provider,
+    set_api_company_id,
+    set_api_token,
+    set_api_token_source,
+)
 
 # Configure logging
 logger = logging.getLogger(__name__)
 
-@dataclass
+
 class NormanAPI:
-    """API client for Norman Finance."""
-    access_token: Optional[str] = None
-    refresh_token: Optional[str] = None
-    company_id: Optional[str] = None
-    token_source: str = "env"  # can be 'env', 'oauth', or 'direct_login'
-    authenticate_on_init: bool = True  # Whether to authenticate on initialization
-    
-    def __post_init__(self):
-        """Initialize the API client by authenticating with Norman Finance."""
-        # If we already have a token, use it
-        if self.access_token:
+    """API client for Norman Finance.
+
+    Per-request state (access_token, company_id, token_source) lives in
+    ``ContextVar``s defined in ``norman_mcp.context`` so that concurrent
+    requests under HTTP/SSE transports don't leak tokens or company ids
+    across users. The class itself is effectively stateless for those
+    fields — they're exposed as properties that read/write the ContextVar.
+
+    The only instance state is ``refresh_token`` (used only by environment
+    credential auth, which is single-user stdio) and ``authenticate_on_init``.
+    """
+
+    def __init__(
+        self,
+        access_token: Optional[str] = None,
+        refresh_token: Optional[str] = None,
+        company_id: Optional[str] = None,
+        token_source: str = "env",
+        authenticate_on_init: bool = True,
+    ):
+        self.refresh_token: Optional[str] = refresh_token
+        self.authenticate_on_init = authenticate_on_init
+
+        if access_token is not None:
+            set_api_token(access_token)
+        if company_id is not None:
+            set_api_company_id(company_id)
+        if token_source != "env":
+            set_api_token_source(token_source)
+
+        if get_api_token():
             return
-            
-        # Skip authentication if requested
+
         if not self.authenticate_on_init:
             logger.info("Skipping automatic authentication on initialization")
             return
-            
-        # Check if credentials are available before attempting authentication
+
         if not config.NORMAN_EMAIL or not config.NORMAN_PASSWORD:
-            logger.warning("Norman Finance credentials not set. Please set NORMAN_EMAIL and NORMAN_PASSWORD environment variables.")
-            logger.warning("The server will start, but API calls will fail until valid credentials are provided.")
+            logger.warning(
+                "Norman Finance credentials not set. Please set NORMAN_EMAIL "
+                "and NORMAN_PASSWORD environment variables."
+            )
+            logger.warning(
+                "The server will start, but API calls will fail until valid "
+                "credentials are provided."
+            )
             return
-        
+
         try:
             self.authenticate()
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 400:
-                logger.warning("Failed to authenticate with Norman Finance API: Invalid credentials.")
-                logger.warning("Please check your NORMAN_EMAIL and NORMAN_PASSWORD environment variables.")
-                logger.warning("The server will start, but API calls will fail until valid credentials are provided.")
+                logger.warning(
+                    "Failed to authenticate with Norman Finance API: Invalid credentials."
+                )
+                logger.warning(
+                    "Please check your NORMAN_EMAIL and NORMAN_PASSWORD environment variables."
+                )
+                logger.warning(
+                    "The server will start, but API calls will fail until valid "
+                    "credentials are provided."
+                )
             else:
                 raise
-    
+
+    # ------------------------------------------------------------------
+    # Per-request properties backed by ContextVars
+    # ------------------------------------------------------------------
+
+    @property
+    def access_token(self) -> Optional[str]:
+        return get_api_token()
+
+    @access_token.setter
+    def access_token(self, value: Optional[str]) -> None:
+        set_api_token(value)
+
+    @property
+    def company_id(self) -> Optional[str]:
+        return get_api_company_id()
+
+    @company_id.setter
+    def company_id(self, value: Optional[str]) -> None:
+        set_api_company_id(value)
+
+    @property
+    def token_source(self) -> str:
+        return get_api_token_source()
+
+    @token_source.setter
+    def token_source(self, value: str) -> None:
+        set_api_token_source(value)
+
+    # ------------------------------------------------------------------
+    # Authentication
+    # ------------------------------------------------------------------
+
     def set_token(self, token: str) -> None:
         """Set the access token directly (used by OAuth flow)."""
         if not token:
             logger.error("Attempted to set empty token!")
             return
-            
-        # If we already have a token from direct login, don't override it with OAuth token
+
         if self.token_source == "direct_login":
             logger.info("Keeping existing direct login token instead of setting OAuth token")
             return
-            
+
         logger.info("Setting Norman API token from OAuth flow")
         self.access_token = token
         self.token_source = "oauth"
-        
-        # Try to get company ID with this token only if we don't already have one
+
         if not self.company_id:
             try:
-                # Try to get company with this token
                 logger.info("Attempting to get company ID with OAuth token")
                 self._set_company_id()
             except Exception as e:
                 logger.error(f"Error setting company ID with OAuth token: {str(e)}")
         else:
             logger.info(f"Using existing company ID: {self.company_id}")
-    
+
     def authenticate(self) -> None:
         """Authenticate with Norman Finance API and get access token."""
         if not config.NORMAN_EMAIL or not config.NORMAN_PASSWORD:
-            raise ValueError("Norman Finance credentials not set. Please set NORMAN_EMAIL and NORMAN_PASSWORD environment variables.")
-        
-        # Extract username from email (as per instructions)
+            raise ValueError(
+                "Norman Finance credentials not set. Please set NORMAN_EMAIL "
+                "and NORMAN_PASSWORD environment variables."
+            )
+
         username = config.NORMAN_EMAIL.split('@')[0]
         auth_url = urljoin(config.api_base_url, "api/v1/auth/token/")
-        
+
         payload = {
             "username": username,
             "email": config.NORMAN_EMAIL,
-            "password": config.NORMAN_PASSWORD
+            "password": config.NORMAN_PASSWORD,
         }
-        
+
         try:
             response = requests.post(auth_url, json=payload, timeout=config.NORMAN_API_TIMEOUT)
             response.raise_for_status()
-            
+
             auth_data = response.json()
             self.access_token = auth_data.get("access")
             self.refresh_token = auth_data.get("refresh")
             self.token_source = "env"
-            
-            # Get company ID (user typically has only one company)
+
             self._set_company_id()
-            
-            logger.info("Successfully authenticated with Norman Finance API using environment credentials")
+
+            logger.info(
+                "Successfully authenticated with Norman Finance API using environment credentials"
+            )
         except requests.exceptions.RequestException as e:
             logger.error(f"Failed to authenticate with Norman Finance API: {str(e)}")
             if hasattr(e, 'response') and e.response is not None:
                 logger.error(f"Response: {e.response.text}")
             raise
-    
+
     def _set_company_id(self) -> None:
-        """Get the company ID for the authenticated user."""
-        # Use the correct URL for getting companies
+        """Get the company ID for the authenticated user and cache it."""
         companies_url = urljoin(config.api_base_url, "api/v1/companies/")
-        
+        token = self.access_token
+        if not token:
+            logger.warning("_set_company_id called with no access token")
+            return
+
         try:
-            logger.info(f"Fetching company information with token: {self.access_token[:8]}...")
-            
-            # Make a request directly, not using self._make_request to avoid recursion
+            logger.info(f"Fetching company information with token: {token[:8]}...")
+
             headers = {
-                "Authorization": f"Bearer {self.access_token}",
+                "Authorization": f"Bearer {token}",
                 "User-Agent": "NormanMCPServer/0.1.0",
-                "X-Requested-With": "XMLHttpRequest"
+                "X-Requested-With": "XMLHttpRequest",
             }
-            
+
             response = requests.get(
                 companies_url,
                 headers=headers,
-                timeout=config.NORMAN_API_TIMEOUT
+                timeout=config.NORMAN_API_TIMEOUT,
             )
-            
             response.raise_for_status()
             response_data = response.json()
-            
+
             companies = response_data.get("results", [])
-            
             if not companies:
                 logger.warning("No companies found for user")
                 return
-            
-            # Use the first company
-            self.company_id = companies[0].get("publicId")
-            if self.company_id:
-                logger.info(f"✅ Using company ID from API: {self.company_id}")
+
+            company_id = companies[0].get("publicId")
+            if company_id:
+                self.company_id = company_id
+                self._persist_company_id_for_session(company_id)
+                logger.info(f"✅ Using company ID from API: {company_id}")
             else:
                 logger.warning("Company found but no publicId available")
-                
         except Exception as e:
             logger.error(f"Error getting company ID: {str(e)}")
-            # Don't set a fallback company ID - let API response indicate the error
-    
-    def _make_request(self, method: str, url: str, params: Optional[Dict[str, Any]] = None, 
-                     json_data: Optional[Dict[str, Any]] = None, 
-                     files: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+
+    # ------------------------------------------------------------------
+    # Core request
+    # ------------------------------------------------------------------
+
+    def _make_request(
+        self,
+        method: str,
+        url: str,
+        params: Optional[Dict[str, Any]] = None,
+        json_data: Optional[Dict[str, Any]] = None,
+        files: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         """Make a request to the Norman Finance API with security controls."""
-        # Always check for a global token first, as it's most reliable
-        try:
-            from norman_mcp.context import get_api_token
-            global_token = get_api_token()
-            if global_token:
-                logger.debug("Using globally stored Norman token from login")
-                self.access_token = global_token
-                self.token_source = "global"
-        except Exception as e:
-            logger.error(f"Error getting global token: {str(e)}")
-        
-        # If still no token, try environment variables as last resort
-        if not self.access_token:
+        token = get_api_token()
+
+        if not token:
             try:
-                logger.warning("No Norman token available. Attempting authentication with environment variables...")
+                logger.warning(
+                    "No Norman token available. Attempting authentication with "
+                    "environment variables..."
+                )
                 self.authenticate()
+                token = get_api_token()
             except Exception as e:
                 logger.error(f"Authentication failed: {str(e)}")
                 return {"error": "No authentication token available. Please authenticate first."}
-        
-        # Validate URL to prevent SSRF attacks
+
+        if not token:
+            return {"error": "No authentication token available. Please authenticate first."}
+
         if not validate_url(url):
             logger.error(f"Invalid or potentially dangerous URL: {url}")
             raise ValueError(f"Invalid or potentially dangerous URL: {url}")
-        
-        # Set secure headers with our token
+
         headers = {
-            "Authorization": f"Bearer {self.access_token}",
+            "Authorization": f"Bearer {token}",
             "User-Agent": "NormanMCPServer/0.1.0",
             "X-Requested-With": "XMLHttpRequest",
-            # Security headers
             "X-Content-Type-Options": "nosniff",
-            "X-Frame-Options": "DENY"
+            "X-Frame-Options": "DENY",
         }
-        
-        # Log token source for debugging
-        logger.debug(f"Making API request to {url} with token source: {self.token_source}")
-        
-        # If we need company ID and don't have one yet, we'll let the API handle it
-        # or we'll get it from the companies endpoint result
-        if not self.company_id and not url.endswith("companies/"):
-            logger.debug("No company ID set yet, will be determined by API or later from companies endpoint")
-        
-        # Add company ID to params if we have one and URL requires it
+
+        logger.debug(
+            f"Making API request to {url} with token source: {self.token_source}"
+        )
+
+        company_id = get_api_company_id()
+
+        if not company_id and not url.endswith("companies/"):
+            logger.debug(
+                "No company ID set yet, will be determined by API or later from companies endpoint"
+            )
+
         if params is None:
             params = {}
-        
-        if self.company_id and not url.endswith("companies/"):
-            # Don't automatically add company ID - let the API determine it
-            logger.debug(f"Using company ID for request: {self.company_id}")
+
+        if company_id and not url.endswith("companies/"):
+            logger.debug(f"Using company ID for request: {company_id}")
             if "companyId" not in params:
-                params["companyId"] = self.company_id
-        
-        # Sanitize parameters to prevent injection
+                params["companyId"] = company_id
+
         if params:
-            sanitized_params = {}
+            sanitized_params: Dict[str, Any] = {}
             for key, value in params.items():
                 if isinstance(value, str):
                     sanitized_params[key] = validate_input(value)
                 else:
                     sanitized_params[key] = value
             params = sanitized_params
-        
-        # Sanitize JSON data to prevent injection
+
         if json_data:
-            sanitized_json = {}
+            sanitized_json: Dict[str, Any] = {}
             for key, value in json_data.items():
                 if isinstance(value, str):
                     sanitized_json[key] = validate_input(value)
                 elif isinstance(value, dict):
-                    # Simple one-level deep sanitization for nested dicts
-                    sanitized_nested = {}
+                    sanitized_nested: Dict[str, Any] = {}
                     for k, v in value.items():
                         if isinstance(v, str):
                             sanitized_nested[k] = validate_input(v)
@@ -234,7 +304,7 @@ class NormanAPI:
                 else:
                     sanitized_json[key] = value
             json_data = sanitized_json
-        
+
         try:
             if files and json_data:
                 response = requests.request(
@@ -244,7 +314,7 @@ class NormanAPI:
                     params=params,
                     data=json_data,
                     files=files,
-                    timeout=config.NORMAN_API_TIMEOUT
+                    timeout=config.NORMAN_API_TIMEOUT,
                 )
             else:
                 response = requests.request(
@@ -254,24 +324,20 @@ class NormanAPI:
                     params=params,
                     json=json_data,
                     files=files,
-                    timeout=config.NORMAN_API_TIMEOUT
+                    timeout=config.NORMAN_API_TIMEOUT,
                 )
             response.raise_for_status()
-            
-            # Attempt to parse JSON response, but handle non-JSON responses gracefully
+
             try:
                 if response.content:
                     return response.json()
                 return {}
             except ValueError:
-                # Not JSON, return content as string if it's not binary
                 if response.headers.get('content-type', '').startswith('text/'):
                     return {"content": response.text}
-                # For binary content, return success message
                 return {"success": True, "message": "Request successful"}
-                
+
         except requests.exceptions.HTTPError as e:
-            # Handle token expiration
             if e.response.status_code == 401:
                 if self.token_source == "env":
                     logger.info("Env token expired, re-authenticating...")
@@ -285,17 +351,13 @@ class NormanAPI:
                         }
                     return self._make_request(method, url, params, json_data, files)
 
-                # OAuth mode: try to refresh the Norman token transparently
-                # using the refresh token we stored at code-exchange time.
                 new_norman_token = self._refresh_oauth_norman_token()
                 if new_norman_token:
-                    self.access_token = new_norman_token
+                    set_api_token(new_norman_token)
                     self.token_source = "global"
                     return self._make_request(method, url, params, json_data, files)
 
                 logger.warning("Cannot refresh Norman token; client must reconnect")
-                self.access_token = None
-                from norman_mcp.context import set_api_token
                 set_api_token(None)
                 return {
                     "error": (
@@ -339,15 +401,18 @@ class NormanAPI:
             logger.error(f"Unexpected error making request to {url}: {str(e)}")
             return {"error": f"Unexpected error: {str(e)}"}
 
+    # ------------------------------------------------------------------
+    # OAuth helpers
+    # ------------------------------------------------------------------
+
     def _refresh_oauth_norman_token(self) -> Optional[str]:
         """Refresh the Norman access token for the current MCP request (OAuth).
 
         Returns the new Norman access token or None if refresh isn't possible.
-        Also updates the global `_api_token` so subsequent requests in this
-        session see the new token.
+        Also updates the per-request token so subsequent calls in this
+        request see the new token.
         """
         try:
-            from norman_mcp.context import get_oauth_provider, set_api_token
             provider = get_oauth_provider()
             if provider is None:
                 return None
@@ -366,6 +431,21 @@ class NormanAPI:
             return None
 
     def set_company(self, company_id: str) -> None:
-        """Manually set a company ID for this API client."""
+        """Set a company id for the current request and persist it for the session."""
         logger.info(f"Manually setting company ID to: {company_id}")
         self.company_id = company_id
+        self._persist_company_id_for_session(company_id)
+
+    def _persist_company_id_for_session(self, company_id: str) -> None:
+        """Cache the company id against the current MCP token so subsequent requests
+        (which each get a fresh ContextVar) pick it up via the provider mapping."""
+        try:
+            provider = get_oauth_provider()
+            if provider is None:
+                return
+            access_token = get_access_token()
+            mcp_token = access_token.token if access_token else None
+            if mcp_token and hasattr(provider, "set_company_for_token"):
+                provider.set_company_for_token(mcp_token, company_id)
+        except Exception as e:
+            logger.debug(f"Could not persist company_id to session: {e}")

--- a/norman_mcp/auth/provider.py
+++ b/norman_mcp/auth/provider.py
@@ -84,6 +84,13 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
 
         self.state_mapping: Dict[str, Dict[str, Any]] = {}
         self.token_mapping: Dict[str, str] = {}
+        # Per-MCP-token company id cache. Populated by the API client the
+        # first time a company id is fetched for a user, and consulted by
+        # load_access_token to seed the per-request ContextVar so that
+        # subsequent requests see the company id without a refetch. Also
+        # updated by switch_company to persist user selections across
+        # requests (ContextVars are per-request only).
+        self.token_to_company_id: Dict[str, str] = {}
 
         self._persist_lock = threading.Lock()
         self._load_state()
@@ -139,6 +146,7 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
                     "refresh_tokens": refresh_ser,
                     "tokens": tokens_ser,
                     "token_mapping": self.token_mapping,
+                    "token_to_company_id": self.token_to_company_id,
                 }
 
                 tmp = path.with_suffix(".tmp")
@@ -189,6 +197,7 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
                     )
 
             self.token_mapping = data.get("token_mapping", {})
+            self.token_to_company_id = data.get("token_to_company_id", {})
             logger.info(
                 "Restored OAuth state: %d clients, %d refresh tokens, %d access tokens",
                 len(self.clients), len(self.refresh_tokens), len(self.tokens),
@@ -389,11 +398,9 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
                 
                 if not norman_token:
                     raise HTTPException(400, "No access token in Norman response")
-                
-                # Store Norman token in global context
-                from norman_mcp.context import set_api_token
-                set_api_token(norman_token)
-                
+
+                # Note: per-request ContextVars are seeded by load_access_token
+                # on each incoming request, so we don't need to set it here.
                 logger.info(f"✅ Norman token obtained: {norman_token[:15]}...")
                 
                 # Generate MCP authorization code for the client
@@ -510,26 +517,84 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
         )
 
     async def load_access_token(self, token: str) -> Optional[AccessToken]:
-        """Load and validate an access token."""
+        """Load and validate an access token and seed per-request context."""
         access_token = self.tokens.get(token)
-        
+
         if not access_token:
             return None
-        
+
         if access_token.expires_at and access_token.expires_at < time.time():
             del self.tokens[token]
             if token in self.token_mapping:
                 del self.token_mapping[token]
+            if token in self.token_to_company_id:
+                del self.token_to_company_id[token]
             self._save_state()
             return None
-        
-        # Set Norman token in context when validating
+
+        # Seed per-request ContextVars so the tool handler sees the right
+        # Norman token and company id for THIS user. ContextVars are
+        # isolated per async task, so concurrent users don't leak state.
+        from norman_mcp.context import (
+            set_api_company_id,
+            set_api_token,
+            set_api_token_source,
+        )
+
         norman_token = self.token_mapping.get(token)
         if norman_token:
-            from norman_mcp.context import set_api_token
             set_api_token(norman_token)
-        
+            set_api_token_source("oauth")
+
+        cached_company_id = self.token_to_company_id.get(token)
+        if not cached_company_id and norman_token:
+            # First request for this session: look up the user's company so
+            # tools that read api.company_id work without a prior set_token().
+            cached_company_id = await self._fetch_company_id(norman_token)
+            if cached_company_id:
+                self.token_to_company_id[token] = cached_company_id
+                self._save_state()
+
+        if cached_company_id:
+            set_api_company_id(cached_company_id)
+
         return access_token
+
+    async def _fetch_company_id(self, norman_token: str) -> Optional[str]:
+        """Resolve the user's primary company id from the Norman API."""
+        companies_url = urljoin(config.api_base_url, "api/v1/companies/")
+        try:
+            async with httpx.AsyncClient() as http_client:
+                response = await http_client.get(
+                    companies_url,
+                    headers={
+                        "Authorization": f"Bearer {norman_token}",
+                        "User-Agent": "NormanMCPServer/0.1.0",
+                        "X-Requested-With": "XMLHttpRequest",
+                    },
+                    timeout=config.NORMAN_API_TIMEOUT,
+                )
+                if response.status_code != 200:
+                    logger.warning(
+                        "Company lookup failed (%s) for norman token %s...",
+                        response.status_code, norman_token[:8],
+                    )
+                    return None
+                companies = response.json().get("results", [])
+                if not companies:
+                    return None
+                return companies[0].get("publicId")
+        except Exception as e:
+            logger.warning("Company lookup raised: %s", e)
+            return None
+
+    def set_company_for_token(self, mcp_token: str, company_id: Optional[str]) -> None:
+        """Persist the active company id against an MCP token across requests."""
+        if company_id:
+            self.token_to_company_id[mcp_token] = company_id
+        else:
+            self.token_to_company_id.pop(mcp_token, None)
+        self._save_state()
 
     async def load_refresh_token(
         self, client: OAuthClientInformationFull, refresh_token: str
@@ -618,6 +683,8 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
         if token in self.tokens:
             if token in self.token_mapping:
                 del self.token_mapping[token]
+            if token in self.token_to_company_id:
+                del self.token_to_company_id[token]
             del self.tokens[token]
             logger.info(f"Revoked access token: {token[:10]}...")
             changed = True

--- a/norman_mcp/context.py
+++ b/norman_mcp/context.py
@@ -1,45 +1,92 @@
+"""Context variables for the Norman MCP server.
+
+Per-request state (Norman access token, company id, token source) lives in
+``contextvars.ContextVar`` so that concurrent requests under the HTTP/SSE
+transports don't leak tokens across users. Each asyncio task inherits the
+current context at creation and can ``set()`` its own value in isolation.
+"""
+
+from contextvars import ContextVar
+from typing import Optional
+
 from mcp.server.fastmcp import Context
 
 # Re-export Context from mcp.server.fastmcp
 # This allows us to use norman_mcp.context.Context throughout the codebase
-# while maintaining a single source of truth 
+# while maintaining a single source of truth.
 
-"""Context variables for the Norman MCP server."""
-
-# Global variable to store the OAuth provider across modules.
-# Set by server.create_app after the provider is constructed.
+# Process-wide singletons (safe to be module globals — not per-request state).
 oauth_provider = None
+_api_client = None
+
 
 def set_oauth_provider(provider):
     """Set the global OAuth provider reference."""
     global oauth_provider
     oauth_provider = provider
 
+
 def get_oauth_provider():
     """Get the global OAuth provider reference (may be None before startup)."""
     return oauth_provider
 
-# Global variable to store the API client
-_api_client = None
-
-# Global variables for direct API access
-_api_token = None
-_api_company_id = None
 
 def set_api_client(client):
     """Set the global API client."""
     global _api_client
     _api_client = client
-    
+
+
 def get_api_client():
     """Get the global API client."""
     return _api_client
 
-def set_api_token(token):
-    """Set the global API token for all API calls."""
-    global _api_token
-    _api_token = token
-    
-def get_api_token():
-    """Get the global API token."""
-    return _api_token
+
+# Per-request state. Module-level globals would leak across concurrent
+# requests — see https://peps.python.org/pep-0567/ for ContextVar semantics.
+_api_token_var: ContextVar[Optional[str]] = ContextVar(
+    "norman_api_token", default=None
+)
+_api_company_id_var: ContextVar[Optional[str]] = ContextVar(
+    "norman_api_company_id", default=None
+)
+_api_token_source_var: ContextVar[str] = ContextVar(
+    "norman_api_token_source", default="env"
+)
+
+
+def set_api_token(token: Optional[str]) -> None:
+    """Set the Norman API token for the current request/task."""
+    _api_token_var.set(token)
+
+
+def get_api_token() -> Optional[str]:
+    """Get the Norman API token for the current request/task."""
+    return _api_token_var.get()
+
+
+def set_api_company_id(company_id: Optional[str]) -> None:
+    """Set the Norman company id for the current request/task."""
+    _api_company_id_var.set(company_id)
+
+
+def get_api_company_id() -> Optional[str]:
+    """Get the Norman company id for the current request/task."""
+    return _api_company_id_var.get()
+
+
+def set_api_token_source(source: str) -> None:
+    """Set the token source label ('env' | 'oauth' | 'global') for the current request."""
+    _api_token_source_var.set(source)
+
+
+def get_api_token_source() -> str:
+    """Get the token source label for the current request."""
+    return _api_token_source_var.get()
+
+
+def reset_request_state() -> None:
+    """Clear all per-request ContextVars. Intended for tests."""
+    _api_token_var.set(None)
+    _api_company_id_var.set(None)
+    _api_token_source_var.set("env")

--- a/norman_mcp/server.py
+++ b/norman_mcp/server.py
@@ -204,12 +204,12 @@ async def authenticate_with_credentials(api_client):
             norman_token = response.json().get("access")
             if not norman_token:
                 return False
-            
+
+            # set_token writes to the per-request ContextVars (access token +
+            # company id). For stdio transport the lifespan context is the
+            # parent of every tool call, so all tool tasks inherit the values.
             api_client.set_token(norman_token)
-            
-            from norman_mcp.context import set_api_token
-            set_api_token(norman_token)
-            
+
             logger.info(f"✅ Authenticated: {norman_email}")
             return True
             
@@ -224,18 +224,20 @@ async def lifespan(app):
     logger.info("Starting Norman MCP server")
     
     api_client = NormanAPI(authenticate_on_init=False)
-    
+
     transport = getattr(app, "_transport", "sse")
     if transport == "stdio":
+        # Stdio is single-user — lifespan task writes the Norman token into
+        # ContextVars and all subsequent tool-call tasks inherit them.
         await authenticate_with_credentials(api_client)
     else:
-        from norman_mcp.context import set_api_client, get_api_token
-        token = get_api_token()
-        if token:
-            api_client.set_token(token)
+        # OAuth/HTTP transports: per-request ContextVars are seeded by
+        # NormanOAuthProvider.load_access_token on each incoming request.
+        # No startup-time token handling is needed.
+        from norman_mcp.context import set_api_client
         set_api_client(api_client)
         logger.info(f"Using {transport} transport with OAuth")
-    
+
     yield {"api": api_client}
     
     logger.info("Shutting down Norman MCP server")

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,156 @@
+"""Concurrency isolation tests for the Norman API client.
+
+Regression coverage for the data-isolation bug where a shared
+``NormanAPI`` singleton + module-global ``_api_token`` would let one
+user's Norman token leak into another user's in-flight request.
+"""
+
+import asyncio
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from norman_mcp.api.client import NormanAPI
+from norman_mcp.context import (
+    get_api_company_id,
+    get_api_token,
+    reset_request_state,
+    set_api_company_id,
+    set_api_token,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_context():
+    """Clear per-request ContextVars between tests."""
+    reset_request_state()
+    yield
+    reset_request_state()
+
+
+def _run(coro):
+    """Run `coro` on a fresh event loop (keeps tests pytest-asyncio-free)."""
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _fake_ok_response(capture):
+    """Build a side_effect that captures Authorization + companyId per call."""
+
+    def _side_effect(method, url, **kwargs):
+        headers = kwargs.get("headers") or {}
+        params = kwargs.get("params") or {}
+        capture.append(
+            {
+                "auth": headers.get("Authorization"),
+                "company": params.get("companyId"),
+            }
+        )
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.content = b"{}"
+        resp.json.return_value = {}
+        resp.headers = {"content-type": "application/json"}
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    return _side_effect
+
+
+def test_two_concurrent_tasks_do_not_leak_tokens():
+    """Two concurrent tasks with different tokens must each send their own."""
+    api = NormanAPI(authenticate_on_init=False)
+    captured: list[dict] = []
+
+    async def do_request(token: str, company_id: str) -> dict:
+        set_api_token(token)
+        set_api_company_id(company_id)
+        # Yield so the sibling task also gets to set its ContextVars before
+        # either one reaches the sync _make_request call.
+        await asyncio.sleep(0)
+        result = api._make_request(
+            "GET", "https://api.norman.finance/api/v1/ping/"
+        )
+        await asyncio.sleep(0)
+        return {
+            "token_after": get_api_token(),
+            "company_after": get_api_company_id(),
+            "result": result,
+        }
+
+    async def main():
+        with patch(
+            "norman_mcp.api.client.requests.request",
+            side_effect=_fake_ok_response(captured),
+        ):
+            return await asyncio.gather(
+                do_request("token_alice", "company_alice"),
+                do_request("token_bob", "company_bob"),
+            )
+
+    alice, bob = _run(main())
+
+    # Each task still sees its own values after the concurrent run.
+    assert alice["token_after"] == "token_alice"
+    assert alice["company_after"] == "company_alice"
+    assert bob["token_after"] == "token_bob"
+    assert bob["company_after"] == "company_bob"
+
+    # And the wire-level request from each task carried that task's pair —
+    # no cross-contamination where Alice's token is sent with Bob's company.
+    by_company = {entry["company"]: entry["auth"] for entry in captured}
+    assert by_company == {
+        "company_alice": "Bearer token_alice",
+        "company_bob": "Bearer token_bob",
+    }
+
+
+def test_contextvars_do_not_leak_into_parent_task():
+    """A child task's set() must not mutate the parent task's ContextVars."""
+    set_api_token("parent_token")
+    set_api_company_id("parent_company")
+
+    async def child():
+        set_api_token("child_token")
+        set_api_company_id("child_company")
+        return get_api_token(), get_api_company_id()
+
+    async def main():
+        child_values = await asyncio.create_task(child())
+        return child_values, (get_api_token(), get_api_company_id())
+
+    child_values, parent_values = _run(main())
+
+    assert child_values == ("child_token", "child_company")
+    assert parent_values == ("parent_token", "parent_company")
+
+
+def test_make_request_uses_contextvar_token_not_instance_state():
+    """A stale instance attribute must not override the per-request ContextVar."""
+    api = NormanAPI(authenticate_on_init=False)
+    captured: list[dict] = []
+
+    # Seed a ContextVar as a request-scoped token would be on the wire.
+    set_api_token("request_scoped_token")
+    set_api_company_id("request_scoped_company")
+
+    # Simulate a stale singleton attribute write from a prior user — on the
+    # pre-refactor code this would win; post-refactor the property writes
+    # back into the ContextVar rather than onto the instance, so it's safe.
+    api.access_token = "legacy_override"
+
+    # Expected behaviour: access_token is a ContextVar property, so the write
+    # above clobbered the ContextVar, not a hidden instance attribute. Restore
+    # the request-scoped value to prove _make_request reads live ContextVar.
+    set_api_token("request_scoped_token")
+
+    with patch(
+        "norman_mcp.api.client.requests.request",
+        side_effect=_fake_ok_response(captured),
+    ):
+        api._make_request(
+            "GET", "https://api.norman.finance/api/v1/ping/"
+        )
+
+    assert captured == [
+        {"auth": "Bearer request_scoped_token", "company": "request_scoped_company"}
+    ]


### PR DESCRIPTION
The singleton NormanAPI + module-global _api_token / _api_company_id could leak one user's Norman token into another user's request under the HTTP/SSE transports. Move per-request state into contextvars so concurrent async tasks each see their own values.

- context.py: ContextVars for access token, company id, token source
- api/client.py: NormanAPI.access_token / company_id / token_source are now properties backed by the ContextVars; _make_request reads from them directly instead of copying the global onto self
- auth/provider.py: load_access_token seeds both token and company id per request; add token_to_company_id cache keyed by MCP token (fetched once on first request, persisted in state file); set_company_for_token lets switch_company survive across requests
- server.py: drop the stale get_api_token/set_token dance in the HTTP-transport lifespan branch and the double token write in authenticate_with_credentials
- tests/test_concurrency.py: regression coverage for the isolation bug (two concurrent tasks keep their own token + company id through an interleaved _make_request)