### PR TITLE
Add vendor (supplier) and bill (PayBill) MCP tools (#72)

### DIFF
--- a/norman_mcp/server.py
+++ b/norman_mcp/server.py
@@ -24,6 +24,8 @@ from mcp.server.auth.routes import validate_issuer_url
 
 from norman_mcp.api.client import NormanAPI
 from norman_mcp.tools.clients import register_client_tools
+from norman_mcp.tools.vendors import register_vendor_tools
+from norman_mcp.tools.bills import register_bill_tools
 from norman_mcp.tools.invoices import register_invoice_tools
 from norman_mcp.tools.taxes import register_tax_tools
 from norman_mcp.tools.transactions import register_transaction_tools
@@ -351,6 +353,8 @@ def create_app(host=None, port=None, public_url=None, transport="sse", streamabl
     
     # Register tools, prompts, and resources
     register_client_tools(server)
+    register_vendor_tools(server)
+    register_bill_tools(server)
     register_invoice_tools(server)
     register_tax_tools(server)
     register_transaction_tools(server)

--- a/norman_mcp/tools/bills.py
+++ b/norman_mcp/tools/bills.py
@@ -164,7 +164,10 @@ def register_bill_tools(mcp):
     )
     async def pay_bill(
         ctx: Context,
-        bill_id: str
+        bill_id: str,
+        account_id: str,
+        execution_date: Optional[str] = None,
+        purpose: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Initiate a SEPA payment for a bill. ⚠️ This starts a REAL payment flow.
@@ -174,6 +177,9 @@ def register_bill_tools(mcp):
 
         Args:
             bill_id: ID of the bill to pay
+            account_id: ID of the bank account to pay from (required by the backend)
+            execution_date: Optional payment execution date in YYYY-MM-DD format
+            purpose: Optional payment purpose / reference text
 
         Returns:
             Payment order details including paymentOrderId and webformUrl
@@ -183,7 +189,12 @@ def register_bill_tools(mcp):
             return {"error": "No company available. Please authenticate first."}
 
         pay_url = urljoin(config.api_base_url, f"api/v1/accounting/bills/{bill_id}/pay/")
-        return api._make_request("POST", pay_url, json_data={})
+        payload: Dict[str, Any] = {"accountId": account_id}
+        if execution_date is not None:
+            payload["executionDate"] = execution_date
+        if purpose is not None:
+            payload["purpose"] = purpose
+        return api._make_request("POST", pay_url, json_data=payload)
 
     @mcp.tool(
         title="Delete Bill",

--- a/norman_mcp/tools/bills.py
+++ b/norman_mcp/tools/bills.py
@@ -1,0 +1,218 @@
+import logging
+from typing import Dict, Any, Optional
+from urllib.parse import urljoin
+
+from mcp.types import ToolAnnotations
+from norman_mcp.context import Context
+from norman_mcp import config
+
+logger = logging.getLogger(__name__)
+
+
+def register_bill_tools(mcp):
+    """Register bill (PayBill / Eingangsrechnung) tools with the MCP server.
+
+    Bills are incoming supplier invoices. Backend routes live under the accounting
+    namespace: ``api/v1/accounting/bills/``. The API client adds the active
+    ``companyId`` as a query param automatically.
+
+    Note: bills are normally created by Norman's email-import inbox
+    (``<handle>@payments.norman.finance``), so this module exposes read / update /
+    pay tools rather than a create tool.
+    """
+
+    @mcp.tool(
+        title="List Bills",
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    )
+    async def list_bills(
+        ctx: Context,
+        status: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Get a list of bills (incoming supplier invoices / Eingangsrechnungen).
+
+        Args:
+            status: Optional status filter (e.g. "PAID", "OPEN")
+
+        Returns:
+            List of bills with their details
+        """
+        api = ctx.request_context.lifespan_context["api"]
+        if not api.company_id:
+            return {"error": "No company available. Please authenticate first."}
+
+        bills_url = urljoin(config.api_base_url, "api/v1/accounting/bills/")
+        params = {"status": status} if status else None
+        return api._make_request("GET", bills_url, params=params)
+
+    @mcp.tool(
+        title="Get Bill Details",
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    )
+    async def get_bill(
+        ctx: Context,
+        bill_id: str
+    ) -> Dict[str, Any]:
+        """
+        Get detailed information about a specific bill.
+
+        Args:
+            bill_id: ID of the bill to retrieve
+
+        Returns:
+            Detailed bill information
+        """
+        api = ctx.request_context.lifespan_context["api"]
+        if not api.company_id:
+            return {"error": "No company available. Please authenticate first."}
+
+        bill_url = urljoin(config.api_base_url, f"api/v1/accounting/bills/{bill_id}/")
+        return api._make_request("GET", bill_url)
+
+    @mcp.tool(
+        title="Update Bill",
+        annotations=ToolAnnotations(
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    )
+    async def update_bill(
+        ctx: Context,
+        bill_id: str,
+        status: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Update an existing bill. Currently supports changing the bill status — e.g.
+        set ``status="PAID"`` to clear a migrated/already-paid bill from the Bills view.
+
+        Args:
+            bill_id: ID of the bill to update
+            status: New status (e.g. "PAID")
+
+        Returns:
+            Updated bill record
+        """
+        api = ctx.request_context.lifespan_context["api"]
+        if not api.company_id:
+            return {"error": "No company available. Please authenticate first."}
+
+        bill_url = urljoin(config.api_base_url, f"api/v1/accounting/bills/{bill_id}/")
+
+        update_data: Dict[str, Any] = {}
+        if status:
+            update_data["status"] = status
+
+        if not update_data:
+            current_data = api._make_request("GET", bill_url)
+            return {"message": "No fields provided for update.", "bill": current_data}
+
+        return api._make_request("PATCH", bill_url, json_data=update_data)
+
+    @mcp.tool(
+        title="Mark Bill as Paid",
+        annotations=ToolAnnotations(
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    )
+    async def mark_bill_paid(
+        ctx: Context,
+        bill_id: str
+    ) -> Dict[str, Any]:
+        """
+        Mark a bill as paid (``status="PAID"``) WITHOUT initiating a payment.
+        Use this for bills that were already paid outside Norman (e.g. migrated
+        bills) to clear them from the Bills view. To actually pay a bill via SEPA,
+        use ``pay_bill`` instead.
+
+        Args:
+            bill_id: ID of the bill to mark paid
+
+        Returns:
+            Updated bill record
+        """
+        api = ctx.request_context.lifespan_context["api"]
+        if not api.company_id:
+            return {"error": "No company available. Please authenticate first."}
+
+        bill_url = urljoin(config.api_base_url, f"api/v1/accounting/bills/{bill_id}/")
+        return api._make_request("PATCH", bill_url, json_data={"status": "PAID"})
+
+    @mcp.tool(
+        title="Pay Bill (SEPA)",
+        annotations=ToolAnnotations(
+            readOnlyHint=False,
+            destructiveHint=True,
+            idempotentHint=False,
+            openWorldHint=True,
+        ),
+    )
+    async def pay_bill(
+        ctx: Context,
+        bill_id: str
+    ) -> Dict[str, Any]:
+        """
+        Initiate a SEPA payment for a bill. ⚠️ This starts a REAL payment flow.
+        Returns a ``paymentOrderId`` and a ``webformUrl`` the user must open to
+        authorise the payment with their bank. Does not move money on its own, but
+        begins the process — only call when the user has explicitly asked to pay.
+
+        Args:
+            bill_id: ID of the bill to pay
+
+        Returns:
+            Payment order details including paymentOrderId and webformUrl
+        """
+        api = ctx.request_context.lifespan_context["api"]
+        if not api.company_id:
+            return {"error": "No company available. Please authenticate first."}
+
+        pay_url = urljoin(config.api_base_url, f"api/v1/accounting/bills/{bill_id}/pay/")
+        return api._make_request("POST", pay_url, json_data={})
+
+    @mcp.tool(
+        title="Delete Bill",
+        annotations=ToolAnnotations(
+            readOnlyHint=False,
+            destructiveHint=True,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    )
+    async def delete_bill(
+        ctx: Context,
+        bill_id: str
+    ) -> Dict[str, Any]:
+        """
+        Delete a bill.
+
+        Args:
+            bill_id: ID of the bill to delete
+
+        Returns:
+            Confirmation of deletion
+        """
+        api = ctx.request_context.lifespan_context["api"]
+        if not api.company_id:
+            return {"error": "No company available. Please authenticate first."}
+
+        bill_url = urljoin(config.api_base_url, f"api/v1/accounting/bills/{bill_id}/")
+        result = api._make_request("DELETE", bill_url)
+        if result is None or result == "":
+            return {"message": f"Bill {bill_id} deleted successfully."}
+        return result

--- a/norman_mcp/tools/vendors.py
+++ b/norman_mcp/tools/vendors.py
@@ -1,0 +1,232 @@
+import logging
+from typing import Dict, Any, Optional
+from urllib.parse import urljoin
+
+from mcp.types import ToolAnnotations
+from norman_mcp.context import Context
+from norman_mcp import config
+
+logger = logging.getLogger(__name__)
+
+
+def register_vendor_tools(mcp):
+    """Register all vendor (supplier / Lieferant) tools with the MCP server.
+
+    Vendors are the supplier-side counterpart of clients. Backend routes live under
+    the accounting namespace: ``api/v1/accounting/vendors/``. The API client adds the
+    active ``companyId`` as a query param automatically.
+    """
+
+    @mcp.tool(
+        title="List Vendors",
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    )
+    async def list_vendors(
+        ctx: Context
+    ) -> Dict[str, Any]:
+        """
+        Get a list of all vendors (suppliers) for the company.
+
+        Returns:
+            List of vendors with their details
+        """
+        api = ctx.request_context.lifespan_context["api"]
+        if not api.company_id:
+            return {"error": "No company available. Please authenticate first."}
+
+        vendors_url = urljoin(config.api_base_url, "api/v1/accounting/vendors/")
+        return api._make_request("GET", vendors_url)
+
+    @mcp.tool(
+        title="Get Vendor Details",
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    )
+    async def get_vendor(
+        ctx: Context,
+        vendor_id: str
+    ) -> Dict[str, Any]:
+        """
+        Get detailed information about a specific vendor.
+
+        Args:
+            vendor_id: ID of the vendor to retrieve
+
+        Returns:
+            Detailed vendor information
+        """
+        api = ctx.request_context.lifespan_context["api"]
+        if not api.company_id:
+            return {"error": "No company available. Please authenticate first."}
+
+        vendor_url = urljoin(config.api_base_url, f"api/v1/accounting/vendors/{vendor_id}/")
+        return api._make_request("GET", vendor_url)
+
+    @mcp.tool(
+        title="Create Vendor",
+        annotations=ToolAnnotations(
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=False,
+            openWorldHint=False,
+        ),
+    )
+    async def create_vendor(
+        ctx: Context,
+        name: str,
+        iban: Optional[str] = None,
+        bic: Optional[str] = None,
+        email: Optional[str] = None,
+        phone: Optional[str] = None,
+        address: Optional[str] = None,
+        country: Optional[str] = None,
+        vat_number: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Create a new vendor (supplier).
+
+        Args:
+            name: Vendor name or business name
+            iban: Vendor bank account IBAN
+            bic: Vendor bank BIC/SWIFT
+            email: Vendor email address
+            phone: Vendor phone number
+            address: Vendor physical address
+            country: Vendor country code (e.g. "DE")
+            vat_number: Vendor VAT number
+
+        Returns:
+            Newly created vendor record
+        """
+        api = ctx.request_context.lifespan_context["api"]
+        if not api.company_id:
+            return {"error": "No company available. Please authenticate first."}
+
+        vendors_url = urljoin(config.api_base_url, "api/v1/accounting/vendors/")
+
+        vendor_data: Dict[str, Any] = {"name": name}
+        if iban:
+            vendor_data["iban"] = iban
+        if bic:
+            vendor_data["bic"] = bic
+        if email:
+            vendor_data["email"] = email
+        if phone:
+            vendor_data["phone"] = phone
+        if address:
+            vendor_data["address"] = address
+        if country:
+            vendor_data["country"] = country
+        if vat_number:
+            vendor_data["vatNumber"] = vat_number
+
+        return api._make_request("POST", vendors_url, json_data=vendor_data)
+
+    @mcp.tool(
+        title="Update Vendor",
+        annotations=ToolAnnotations(
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    )
+    async def update_vendor(
+        ctx: Context,
+        vendor_id: str,
+        name: Optional[str] = None,
+        iban: Optional[str] = None,
+        bic: Optional[str] = None,
+        email: Optional[str] = None,
+        phone: Optional[str] = None,
+        address: Optional[str] = None,
+        country: Optional[str] = None,
+        vat_number: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Update an existing vendor. Only the fields you pass are changed.
+
+        Args:
+            vendor_id: ID of the vendor to update
+            name: Updated vendor name
+            iban: Updated IBAN
+            bic: Updated BIC/SWIFT
+            email: Updated email address
+            phone: Updated phone number
+            address: Updated physical address
+            country: Updated country code (e.g. "DE")
+            vat_number: Updated VAT number
+
+        Returns:
+            Updated vendor record
+        """
+        api = ctx.request_context.lifespan_context["api"]
+        if not api.company_id:
+            return {"error": "No company available. Please authenticate first."}
+
+        vendor_url = urljoin(config.api_base_url, f"api/v1/accounting/vendors/{vendor_id}/")
+
+        update_data: Dict[str, Any] = {}
+        if name:
+            update_data["name"] = name
+        if iban:
+            update_data["iban"] = iban
+        if bic:
+            update_data["bic"] = bic
+        if email:
+            update_data["email"] = email
+        if phone:
+            update_data["phone"] = phone
+        if address:
+            update_data["address"] = address
+        if country:
+            update_data["country"] = country
+        if vat_number:
+            update_data["vatNumber"] = vat_number
+
+        if not update_data:
+            current_data = api._make_request("GET", vendor_url)
+            return {"message": "No fields provided for update.", "vendor": current_data}
+
+        return api._make_request("PATCH", vendor_url, json_data=update_data)
+
+    @mcp.tool(
+        title="Delete Vendor",
+        annotations=ToolAnnotations(
+            readOnlyHint=False,
+            destructiveHint=True,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    )
+    async def delete_vendor(
+        ctx: Context,
+        vendor_id: str
+    ) -> Dict[str, Any]:
+        """
+        Delete a vendor.
+
+        Args:
+            vendor_id: ID of the vendor to delete
+
+        Returns:
+            Confirmation of deletion
+        """
+        api = ctx.request_context.lifespan_context["api"]
+        if not api.company_id:
+            return {"error": "No company available. Please authenticate first."}
+
+        vendor_url = urljoin(config.api_base_url, f"api/v1/accounting/vendors/{vendor_id}/")
+        result = api._make_request("DELETE", vendor_url)
+        if result is None or result == "":
+            return {"message": f"Vendor {vendor_id} deleted successfully."}
+        return result


### PR DESCRIPTION
Closes #72.

Adds the supplier/vendor and incoming-bill (PayBill) MCP tools requested in #72, following the patterns in `tools/clients.py`.

## Vendors — `api/v1/accounting/vendors/`
`list_vendors`, `get_vendor`, `create_vendor`, `update_vendor`, `delete_vendor`.
Fields per your guidance: `name`, `iban`, `bic`, `email`, `phone`, `address`, `country`, `vatNumber`.

## Bills / PayBill — `api/v1/accounting/bills/`
`list_bills` (optional `status` filter), `get_bill`, `update_bill` (status), `mark_bill_paid` (PATCH `status: "PAID"` to clear already-paid / migrated bills), `pay_bill` (`POST .../{billId}/pay/` → returns `paymentOrderId` + `webformUrl`), `delete_bill`.
No `create_bill` — bills normally arrive via the email-import inbox; happy to add it if you'd like.

Both modules are registered in `server.py`. The API client appends the active `companyId` automatically, so the accounting routes are company-scoped without extra work.

## Testing
Verified against the live API with env-credential auth: `GET accounting/vendors/` and `GET accounting/bills/` both return paginated results. Write paths follow the documented fields/endpoints.

Happy to split this into separate vendor / bill PRs if you'd prefer that for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
