### PR TITLE
validate_input: drop SQL-keyword blocklist that corrupts normal input (#74)

### DIFF
--- a/norman_mcp/security/utils.py
+++ b/norman_mcp/security/utils.py
@@ -7,26 +7,35 @@ from urllib.parse import urlparse
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
+# HTML/JS injection patterns only. We deliberately do NOT strip SQL keywords or
+# characters like '@'. These values are passed to the Norman API as JSON bodies /
+# query parameters — never interpolated into SQL — so a SQL-keyword blocklist
+# provides no real protection while silently corrupting legitimate input:
+#   "PENDING" -> "PING" (strips "end"), "OpenAI" -> "AI" (strips "open"),
+#   "foo@example.com" -> "fooexample.com" (strips "@"), and "create"/"update"/
+#   "delete"/"table" vanish entirely. That broke, e.g., the bills status=PENDING filter.
+_SCRIPT_INJECTION_RE = re.compile(
+    r'<script|javascript:|onclick|onload|onerror|onmouseover|'
+    r'alert\(|confirm\(|prompt\(|eval\(|setTimeout\(|setInterval\(',
+    re.IGNORECASE,
+)
+
+
 def validate_input(input_str: Optional[str]) -> Optional[str]:
-    """Validate and sanitize input strings to prevent injection attacks."""
+    """Sanitize input strings, stripping only obvious HTML/JS injection patterns.
+
+    Normal text — including SQL-keyword substrings (``end``, ``open``, ``create``,
+    ``update``, ``select``) and ``@`` — is returned unchanged, since these are sent
+    as JSON/query params, not raw SQL.
+    """
     if input_str is None:
         return None
-        
-    # Remove any suspicious patterns that might indicate injection attempts
-    # This prevents SQL injection, command injection, etc.
-    dangerous_patterns = [
-        r'--|;|\/\*|\*\/|@@|@|char|nchar|varchar|nvarchar|alter|begin|cast|create|cursor|declare|delete|drop|end|exec|execute|fetch|insert|kill|open|select|sys|sysobjects|syscolumns|table|update',
-        r'<script|javascript:|onclick|onload|onerror|onmouseover|alert\(|confirm\(|prompt\(|eval\(|setTimeout\(|setInterval\(',
-    ]
-    
-    sanitized = input_str
-    for pattern in dangerous_patterns:
-        if re.search(pattern, sanitized, re.IGNORECASE):
-            logger.warning(f"Potential injection attack detected in input: {input_str}")
-            # Replace potential injection patterns with empty string
-            sanitized = re.sub(pattern, '', sanitized, flags=re.IGNORECASE)
-    
-    return sanitized
+
+    if _SCRIPT_INJECTION_RE.search(input_str):
+        logger.warning("Potential script-injection pattern detected in input; sanitizing.")
+        return _SCRIPT_INJECTION_RE.sub('', input_str)
+
+    return input_str
 
 def validate_file_path(file_path: str) -> bool:
     """Validate a file path to prevent path traversal attacks."""

--- a/tests/test_validate_input.py
+++ b/tests/test_validate_input.py
@@ -1,0 +1,37 @@
+"""Regression tests for norman_mcp.security.utils.validate_input.
+
+The old implementation stripped SQL-keyword substrings (and '@'), silently
+corrupting legitimate input such as status="PENDING" -> "PING" or "OpenAI" -> "AI".
+These tests pin the corrected behaviour: normal text passes through unchanged,
+only HTML/JS injection patterns are stripped.
+"""
+import pytest
+
+from norman_mcp.security.utils import validate_input
+
+
+@pytest.mark.parametrize("value", [
+    "PENDING",            # contains "end" — must NOT become "PING"
+    "PAID",
+    "OpenAI",             # contains "open" — must NOT become "AI"
+    "foo@example.com",    # the "@" must survive
+    "end", "open", "create", "update", "delete", "select", "table",
+    "Invoice for September 2025",
+    "Acme GmbH & Co. KG",
+])
+def test_preserves_normal_text(value):
+    assert validate_input(value) == value
+
+
+def test_none_passthrough():
+    assert validate_input(None) is None
+
+
+def test_empty_string():
+    assert validate_input("") == ""
+
+
+def test_strips_script_injection():
+    assert "<script" not in validate_input("<script>alert(1)</script>").lower()
+    assert "javascript:" not in validate_input("javascript:alert(1)").lower()
+    assert "alert(" not in validate_input("x = alert(1)")


### PR DESCRIPTION
Fixes #74.

`validate_input` stripped SQL-keyword substrings (and `@`) from every input, silently mangling legitimate values:

- `PENDING` → `PING` (strips `end`)
- `OpenAI` → `AI` (strips `open`)
- `foo@example.com` → `fooexample.com`
- `create` / `update` / `delete` / `table` / `select` → removed entirely

These values are sent as JSON bodies / query params to the Norman API (never interpolated into SQL), so the blocklist gave no real protection while breaking real input (e.g. the bills `status=PENDING` filter).

**Change:** remove the SQL-keyword pattern; keep the HTML/JS injection cleanup (`<script`, `javascript:`, inline handlers, `eval(`, …). Added `tests/test_validate_input.py` covering `PENDING`, `OpenAI`, `foo@example.com` (preserved) and script stripping (still works). 16 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)