### PR TITLE
Add delete_attachment tool

### DIFF
--- a/norman_mcp/tools/documents.py
+++ b/norman_mcp/tools/documents.py
@@ -628,6 +628,45 @@ def register_document_tools(mcp):
         
         return api._make_request("POST", link_url, json_data=link_data)
 
+    @mcp.tool(
+        title="Delete Attachment",
+        annotations=ToolAnnotations(
+            readOnlyHint=False,
+            destructiveHint=True,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    )
+    async def delete_attachment(
+        ctx: Context,
+        attachment_id: str = Field(description="ID of the attachment to delete"),
+    ) -> Dict[str, Any]:
+        """
+        Delete an attachment. Useful for removing an orphan receipt/invoice that has
+        no linked transaction (e.g. a stale self-statement left behind after the real
+        invoice was attached). Permanent — only call once the user has confirmed the
+        attachment should be removed.
+
+        Args:
+            attachment_id: ID of the attachment to delete
+
+        Returns:
+            Confirmation of deletion
+        """
+        api = ctx.request_context.lifespan_context["api"]
+        company_id = api.company_id
+        if not company_id:
+            return {"error": "No company available. Please authenticate first."}
+
+        attachment_url = urljoin(
+            config.api_base_url,
+            f"api/v1/companies/{company_id}/attachments/{attachment_id}/",
+        )
+        result = api._make_request("DELETE", attachment_url)
+        if result is None or result == "":
+            return {"message": f"Attachment {attachment_id} deleted successfully."}
+        return result
+
     _IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".tif"}
     _EXT_TO_MIME = {
         ".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg",

--- a/norman_mcp/tools/documents.py
+++ b/norman_mcp/tools/documents.py
@@ -651,13 +651,13 @@ def register_document_tools(mcp):
         ),
     ) -> Dict[str, Any]:
         """
-        Delete an attachment. Useful for removing an orphan receipt/invoice that has
-        no linked transaction (e.g. a stale self-statement left behind after the real
-        invoice was attached). Permanent.
+        Delete an attachment — e.g. an orphan receipt/invoice with no linked transaction
+        (a stale self-statement left behind after the real invoice was attached).
 
-        Documents subject to retention return a 409 whose `detail.requiresConfirmation`
-        is true (with a `retentionUntil` date). To proceed, re-call with `confirm=true`.
-        Only call once the user has confirmed the attachment should be removed.
+        Retention-aware: Norman keeps documents under GoBD retention. A retained document
+        returns a 409 whose `detail.requiresConfirmation` is true (with a `retentionUntil`
+        date); re-call with `confirm=true` to override. Only call once the user has
+        confirmed the attachment should be removed.
 
         Args:
             attachment_id: ID of the attachment to delete
@@ -675,9 +675,11 @@ def register_document_tools(mcp):
             config.api_base_url,
             f"api/v1/companies/{company_id}/attachments/{attachment_id}/",
         )
-        params = {"confirm": "true"} if confirm else None
+        # Backend expects ?confirmed=true to override the GoBD retention guard.
+        params = {"confirmed": "true"} if confirm else None
         result = api._make_request("DELETE", attachment_url, params=params)
-        if result is None or result == "":
+        # _make_request returns {} on an empty 204 response — treat any falsy result as success.
+        if not result:
             return {"message": f"Attachment {attachment_id} deleted successfully."}
         return result
 

--- a/norman_mcp/tools/documents.py
+++ b/norman_mcp/tools/documents.py
@@ -640,18 +640,31 @@ def register_document_tools(mcp):
     async def delete_attachment(
         ctx: Context,
         attachment_id: str = Field(description="ID of the attachment to delete"),
+        confirm: bool = Field(
+            default=False,
+            description=(
+                "Documents under legal retention (GoBD, ~10 years) cannot be deleted "
+                "without confirmation — the API returns 409 with requiresConfirmation. "
+                "Set true to confirm and override the retention guard. Only do this on "
+                "the user's explicit instruction to delete a retained document."
+            ),
+        ),
     ) -> Dict[str, Any]:
         """
         Delete an attachment. Useful for removing an orphan receipt/invoice that has
         no linked transaction (e.g. a stale self-statement left behind after the real
-        invoice was attached). Permanent — only call once the user has confirmed the
-        attachment should be removed.
+        invoice was attached). Permanent.
+
+        Documents subject to retention return a 409 whose `detail.requiresConfirmation`
+        is true (with a `retentionUntil` date). To proceed, re-call with `confirm=true`.
+        Only call once the user has confirmed the attachment should be removed.
 
         Args:
             attachment_id: ID of the attachment to delete
+            confirm: set true to override the legal-retention guard on a retained document
 
         Returns:
-            Confirmation of deletion
+            Confirmation of deletion, or the 409 retention warning if confirm is not set
         """
         api = ctx.request_context.lifespan_context["api"]
         company_id = api.company_id
@@ -662,7 +675,8 @@ def register_document_tools(mcp):
             config.api_base_url,
             f"api/v1/companies/{company_id}/attachments/{attachment_id}/",
         )
-        result = api._make_request("DELETE", attachment_url)
+        params = {"confirm": "true"} if confirm else None
+        result = api._make_request("DELETE", attachment_url, params=params)
         if result is None or result == "":
             return {"message": f"Attachment {attachment_id} deleted successfully."}
         return result


### PR DESCRIPTION
Adds a `delete_attachment` MCP tool — `DELETE /api/v1/companies/{companyId}/attachments/{attachmentId}/` — mirroring the existing `delete_bill` / `delete_vendor` / `delete_client` tools.

**Motivation:** there's currently no way to remove an attachment via the MCP. We hit this with an **orphan attachment** — a stale self-statement PDF left behind after the real invoice got attached to the transaction (the orphan had `transactions: []`). `list_attachments` surfaces it but nothing could remove it.

- `readOnlyHint=False`, `destructiveHint=True` (permanent delete); returns a confirmation message on an empty 204 body, like `delete_bill`.

**Follow-up idea:** an `unlink_attachment_transaction` (inverse of the existing `link_attachment_transaction`) would round out the set for the "linked the wrong thing" case — happy to add it if you can point me at the unlink endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)