### PR TITLE
docs: add a 'Try asking' example-prompts block to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@
 
 <br/>
 
+### 💬 Try asking
+
+Once connected, talk to your books in plain language:
+
+- *"Prepare and file my UStVA for last month."*
+- *"Send a €1,200 invoice to ACME for consulting."*
+- *"What did I spend on software this quarter?"*
+- *"Find tax deductions I might have missed."*
+- *"Which invoices are overdue? Send reminders."*
+
+<br/>
+
 <details open>
 <summary>
 <h3>👀 See it in action</h3>


### PR DESCRIPTION
### What
Adds a concise **"Try asking"** block to the README, right under *What you can do* — a short list of natural-language example prompts (file UStVA, send an invoice, quarterly expenses, missed deductions, overdue reminders).

### Why
The README has great screenshots but no copy-paste prompts. Concrete example prompts are the fastest way for a new user to grasp what to *do* right after connecting — lowering time-to-first-action and "now what?" drop-off. Each maps to an existing skill (`tax-report`, `create-invoice`, `expense-report`, `tax-deduction-finder`, `overdue-reminders`).

### Scope
Purely additive — one small block, no other changes. Happy to tweak wording or placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
