### PR TITLE
fix(transport): run streamable-http stateless so hosted clients (Claude/ChatGPT) load tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,15 @@ ENV PYTHONUNBUFFERED=1
 # Expose server port
 EXPOSE 3001
 
-# Run the server with streamable-http transport (OAuth-enabled)
-CMD ["python", "-m", "norman_mcp", "--transport", "streamable-http", "--environment", "production", "--host", "0.0.0.0", "--port", "3001"]
+# Run the server with streamable-http transport (OAuth-enabled).
+#
+# --stateless is REQUIRED for hosted connectors. In stateful mode FastMCP keeps
+# each session in memory and demands the exact Mcp-Session-Id be replayed on
+# every request after initialize. Hosted clients (claude.ai, ChatGPT) do not
+# reliably thread that session id across their conversation runtime, and a
+# redeploy/restart wipes the single replica's in-memory sessions. Symptom:
+# tools show in the connector settings (cached from the discovery sync) but
+# fail to load in conversations with "400 Bad Request: Missing session ID".
+# Stateless makes every request self-contained. Do not remove without moving
+# session state to a shared store.
+CMD ["python", "-m", "norman_mcp", "--transport", "streamable-http", "--stateless", "--environment", "production", "--host", "0.0.0.0", "--port", "3001"]


### PR DESCRIPTION
## Problem

Customer report: the connector adds fine, OAuth completes, the settings page lists the tools with permissions — but **the tools never appear in conversations** (fresh chats, web + desktop, reconnects). Other custom connectors work in the same account; only Norman is affected.

## Root cause

The production image runs the streamable-HTTP transport **stateful** (`Dockerfile` CMD has no `--stateless` → [`create_app`](norman_mcp/server.py) default `{"stateless": False}`). In stateful mode FastMCP keeps each session **in memory** and requires the exact `Mcp-Session-Id` from `initialize` to be replayed on **every** subsequent request.

Hosted connectors (claude.ai, ChatGPT) do not reliably thread that per-session id across their conversation runtime, and the single replica's in-memory sessions are wiped on every redeploy/restart (`order: start-first`, local `mcp-data` volume). So:

- The connector **settings** page shows a **cached** tool list from the last successful discovery sync (this is why the customer still sees a stale count).
- The **conversation** runtime re-connects and its `tools/list` lands without a valid session → **`400 Bad Request: Missing session ID`** → no tools injected.

## Reproduction (prod config, local)

Minted a token via the OAuth state file and drove the exact Claude-style handshake. `tools/list` does not touch the Norman API, so this isolates the transport:

| Scenario | Stateful (prod) | Stateless (this PR) |
|---|---|---|
| session id threaded correctly | tools ✅ | tools ✅ |
| `tools/list` without session id | **400 Missing session ID** ❌ | tools ✅ |
| cold `tools/list`, no init | **400 Missing session ID** ❌ | tools ✅ |

## Fix

Add `--stateless` to the Docker `CMD` so every request is self-contained.

**Safe:** no tool uses stateful-only features (`report_progress`/sampling/elicitation/server notifications — grepped, none); the api client comes from the lifespan context (available per-request in stateless); the Norman token is set per-request by the auth middleware. Also removes the redeploy-wipes-sessions fragility and unblocks future horizontal scaling.

## Verify on prod after deploy

```
docker service logs --since 2h norman_mcp | grep -iE "Missing session ID|Session not found"
```
A stream of these 400s before the deploy confirms the cause; they should stop after. Customers should disconnect/reconnect the connector once post-deploy to refresh the cached tool list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)