### PR TITLE
docs(incorporation): invite the user back to the Norman dashboard aft…

### DIFF
--- a/norman_mcp/tools/incorporation.py
+++ b/norman_mcp/tools/incorporation.py
@@ -406,6 +406,11 @@ def register_incorporation_tools(mcp):
 
         Get the user's explicit confirmation before calling. The Norman team coordinates the
         appointment and gets back to the user; nothing is sent to a notary automatically.
+
+        After this succeeds, present the remaining formation steps from the record's `roadmap`
+        and invite the user back into the product to continue: their Norman dashboard at
+        https://app.norman.finance/ has the formation roadmap (bank account, deposit, HRB,
+        Finanzamt, Gewerbeamt, Transparency) where they track and complete each step.
         """
         api = ctx.request_context.lifespan_context.get("api")
         payload = _clean({"notaryPublicId": notary_public_id, "message": message or None})

--- a/skills/company-incorporation/SKILL.md
+++ b/skills/company-incorporation/SKILL.md
@@ -99,6 +99,13 @@ steps (3-9 of the journey). Drive from `roadmap` (each has `done`/`active`); mar
 `complete_incorporation_step` (undoable). These are the founder's own checklist — they do not
 send emails and never move the official `status` backwards.
 
+**Whenever you present these next steps, send the user back into the product.** Point them to
+their Norman dashboard — **https://app.norman.finance/** — and invite them to continue there.
+The Home formation roadmap in the app shows exactly these remaining steps, adds bank-account
+partner cards (Qonto/Vivid/Tide) for the deposit, and lets them tick each step done and ask
+follow-up questions per step. Always close the incorporation chat with this invitation to open
+the dashboard and track the rest of the founding.
+
 1. `notary` — schedule the notary and sign the Articles.
 2. `bank_account` — open a business account (needed for the deposit). Norman shows partner
    options (Qonto/Vivid/Tide) in the product.


### PR DESCRIPTION
…er notary hand-off

When presenting the remaining formation steps, point the user to https://app.norman.finance/ (Home formation roadmap) to continue in the product — SKILL.md roadmap section + request_incorporation_notary tool docstring.