### PR TITLE
fix: scope API identity to the request

### DIFF
--- a/norman_mcp/api/client.py
+++ b/norman_mcp/api/client.py
@@ -7,20 +7,106 @@ from urllib.parse import urljoin
 from ..config.settings import config
 from ..security.utils import validate_input, validate_url
 from mcp.server.auth.middleware.auth_context import get_access_token
-from norman_mcp.context import oauth_provider
+from norman_mcp.context import (
+    get_api_company_id,
+    get_api_token,
+    get_oauth_provider,
+    set_api_company_id,
+    set_api_token,
+)
 
 # Configure logging
 logger = logging.getLogger(__name__)
 
 @dataclass
 class NormanAPI:
-    """API client for Norman Finance."""
+    """API client for Norman Finance.
+
+    SECURITY: in OAuth mode this object may be shared between concurrent users
+    (SSE/stateful transports reuse one instance; stateless HTTP rebuilds it per
+    request). It therefore must NOT hold per-request identity. The Norman token
+    is resolved per call by `_resolve_norman_token()` and the company id by the
+    `company_id` property -- both request-scoped. `access_token` /
+    `_env_company_id` below are only for single-tenant env/stdio mode.
+    """
     access_token: Optional[str] = None
     refresh_token: Optional[str] = None
-    company_id: Optional[str] = None
     token_source: str = "env"  # can be 'env', 'oauth', or 'direct_login'
     authenticate_on_init: bool = True  # Whether to authenticate on initialization
-    
+    # Single-tenant (env/stdio) company id only. In OAuth mode the company id is
+    # per-request and lives in a ContextVar -- see the `company_id` property.
+    _env_company_id: Optional[str] = None
+
+    @property
+    def company_id(self) -> Optional[str]:
+        """The company id for the CURRENT request.
+
+        Resolved from the requesting user's own token, cached per request. It is
+        deliberately never a plain attribute in OAuth mode: a shared attribute
+        pinned whichever company happened to be looked up first and handed it to
+        every later caller.
+        """
+        if self.token_source == "env":
+            return self._env_company_id
+
+        cached = get_api_company_id()
+        if cached:
+            return cached
+
+        token = self._resolve_norman_token()
+        if not token:
+            return None
+
+        company_id = self._fetch_company_id(token)
+        if company_id:
+            set_api_company_id(company_id)
+        return company_id
+
+    @company_id.setter
+    def company_id(self, value: Optional[str]) -> None:
+        if self.token_source == "env":
+            self._env_company_id = value
+        else:
+            set_api_company_id(value)
+
+    def _resolve_norman_token(self) -> Optional[str]:
+        """Resolve the Norman access token for the CURRENT request.
+
+        The order here is a security boundary, not a convenience:
+
+        1. The MCP auth context (`get_access_token()`) is set per request by the
+           SDK's auth middleware and is the only trustworthy caller identity in
+           a multi-tenant process. Map it to a Norman token via the provider.
+        2. The request-scoped ContextVar, for transports with no auth context
+           (stdio) and for the transparent-refresh path.
+        3. `self.access_token` -- ONLY in single-tenant env mode.
+
+        Never fall back from an authenticated request to shared instance state:
+        that is exactly how one user ends up querying with another user's token.
+        """
+        try:
+            access_token = get_access_token()
+        except Exception:  # no auth context on this transport
+            access_token = None
+
+        if access_token is not None:
+            mcp_token = getattr(access_token, "token", None)
+            provider = get_oauth_provider()
+            if provider is not None and mcp_token:
+                norman_token = provider.get_norman_token(mcp_token)
+                if norman_token:
+                    return norman_token
+            # Authenticated but unresolvable: use only the request-scoped value.
+            return get_api_token()
+
+        scoped = get_api_token()
+        if scoped:
+            return scoped
+
+        if self.token_source == "env":
+            return self.access_token
+        return None
+
     def __post_init__(self):
         """Initialize the API client by authenticating with Norman Finance."""
         # If we already have a token, use it
@@ -48,32 +134,55 @@ class NormanAPI:
             else:
                 raise
     
-    def set_token(self, token: str) -> None:
-        """Set the access token directly (used by OAuth flow)."""
+    def set_token(self, token: str, single_tenant: bool = False) -> None:
+        """Set the access token.
+
+        Args:
+            token: the Norman access token.
+            single_tenant: True for stdio/env credential login, where the whole
+                process serves exactly one user and the token may legitimately
+                live on the instance. False (default) for OAuth, where the token
+                belongs to one request only and MUST stay request-scoped -- one
+                shared instance serves every connected user there.
+        """
         if not token:
             logger.error("Attempted to set empty token!")
             return
-            
+
         # If we already have a token from direct login, don't override it with OAuth token
         if self.token_source == "direct_login":
             logger.info("Keeping existing direct login token instead of setting OAuth token")
             return
-            
-        logger.info("Setting Norman API token from OAuth flow")
-        self.access_token = token
-        self.token_source = "oauth"
-        
-        # Try to get company ID with this token only if we don't already have one
-        if not self.company_id:
+
+        if single_tenant:
+            logger.info("Setting Norman API token from credential login (single tenant)")
+            self.access_token = token
+            self.token_source = "env"
             try:
-                # Try to get company with this token
-                logger.info("Attempting to get company ID with OAuth token")
                 self._set_company_id()
             except Exception as e:
-                logger.error(f"Error setting company ID with OAuth token: {str(e)}")
-        else:
-            logger.info(f"Using existing company ID: {self.company_id}")
-    
+                logger.error(f"Error setting company ID: {str(e)}")
+            return
+
+        logger.info("Setting Norman API token from OAuth flow")
+        self.token_source = "oauth"
+
+        # Do NOT store the token on self: this object can be shared between
+        # concurrent users. Keep it request-scoped; _resolve_norman_token()
+        # re-derives it per call from the request's own auth context.
+        set_api_token(token)
+
+        # Resolve the company for THIS request's token. Previously guarded by
+        # `if not self.company_id`, which pinned the first user's company onto
+        # the shared client and handed it to everyone who came after.
+        try:
+            company_id = self._fetch_company_id(token)
+            if company_id:
+                set_api_company_id(company_id)
+        except Exception as e:
+            logger.error(f"Error setting company ID with OAuth token: {str(e)}")
+
+
     def authenticate(self) -> None:
         """Authenticate with Norman Finance API and get access token."""
         if not config.NORMAN_EMAIL or not config.NORMAN_PASSWORD:
@@ -109,16 +218,27 @@ class NormanAPI:
             raise
     
     def _set_company_id(self) -> None:
-        """Get the company ID for the authenticated user."""
+        """Resolve and store the company id for the env/stdio token."""
+        self.company_id = self._fetch_company_id(self.access_token)
+
+    def _fetch_company_id(self, token: Optional[str]) -> Optional[str]:
+        """Look up the first company for `token`'s owner.
+
+        Pure in the token: it stores nothing on `self`, so it is safe to call
+        concurrently for different users.
+        """
+        if not token:
+            return None
+
         # Use the correct URL for getting companies
         companies_url = urljoin(config.api_base_url, "api/v1/companies/")
-        
+
         try:
-            logger.info(f"Fetching company information with token: {self.access_token[:8]}...")
-            
+            logger.info(f"Fetching company information with token: {token[:8]}...")
+
             # Make a request directly, not using self._make_request to avoid recursion
             headers = {
-                "Authorization": f"Bearer {self.access_token}",
+                "Authorization": f"Bearer {token}",
                 "User-Agent": "NormanMCPServer/0.1.0",
                 "X-Requested-With": "XMLHttpRequest"
             }
@@ -136,76 +256,75 @@ class NormanAPI:
             
             if not companies:
                 logger.warning("No companies found for user")
-                return
-            
+                return None
+
             # Use the first company
-            self.company_id = companies[0].get("publicId")
-            if self.company_id:
-                logger.info(f"✅ Using company ID from API: {self.company_id}")
+            company_id = companies[0].get("publicId")
+            if company_id:
+                logger.info(f"✅ Using company ID from API: {company_id}")
             else:
                 logger.warning("Company found but no publicId available")
-                
+            return company_id
+
         except Exception as e:
             logger.error(f"Error getting company ID: {str(e)}")
             # Don't set a fallback company ID - let API response indicate the error
-    
+            return None
+
+
     def _make_request(self, method: str, url: str, params: Optional[Dict[str, Any]] = None, 
                      json_data: Optional[Dict[str, Any]] = None, 
                      files: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Make a request to the Norman Finance API with security controls."""
-        # Always check for a global token first, as it's most reliable
-        try:
-            from norman_mcp.context import get_api_token
-            global_token = get_api_token()
-            if global_token:
-                logger.debug("Using globally stored Norman token from login")
-                self.access_token = global_token
-                self.token_source = "global"
-        except Exception as e:
-            logger.error(f"Error getting global token: {str(e)}")
-        
-        # If still no token, try environment variables as last resort
-        if not self.access_token:
+        # Resolve the caller's token for THIS request. Keep it in a local: it
+        # must never be written to `self`, which is shared across users.
+        token = self._resolve_norman_token()
+
+        # No token and single-tenant mode: env credentials are the last resort.
+        if not token and self.token_source == "env":
             try:
                 logger.warning("No Norman token available. Attempting authentication with environment variables...")
                 self.authenticate()
+                token = self.access_token
             except Exception as e:
                 logger.error(f"Authentication failed: {str(e)}")
                 return {"error": "No authentication token available. Please authenticate first."}
-        
+
+        if not token:
+            logger.error("No Norman token resolvable for this request")
+            return {"error": "No authentication token available. Please authenticate first."}
+
         # Validate URL to prevent SSRF attacks
         if not validate_url(url):
             logger.error(f"Invalid or potentially dangerous URL: {url}")
             raise ValueError(f"Invalid or potentially dangerous URL: {url}")
-        
+
         # Set secure headers with our token
         headers = {
-            "Authorization": f"Bearer {self.access_token}",
+            "Authorization": f"Bearer {token}",
             "User-Agent": "NormanMCPServer/0.1.0",
             "X-Requested-With": "XMLHttpRequest",
             # Security headers
             "X-Content-Type-Options": "nosniff",
             "X-Frame-Options": "DENY"
         }
-        
+
         # Log token source for debugging
         logger.debug(f"Making API request to {url} with token source: {self.token_source}")
-        
-        # If we need company ID and don't have one yet, we'll let the API handle it
-        # or we'll get it from the companies endpoint result
-        if not self.company_id and not url.endswith("companies/"):
-            logger.debug("No company ID set yet, will be determined by API or later from companies endpoint")
-        
-        # Add company ID to params if we have one and URL requires it
+
         if params is None:
             params = {}
-        
-        if self.company_id and not url.endswith("companies/"):
-            # Don't automatically add company ID - let the API determine it
-            logger.debug(f"Using company ID for request: {self.company_id}")
-            if "companyId" not in params:
-                params["companyId"] = self.company_id
-        
+
+        # Add company ID to params if we have one and the URL requires it.
+        # `self.company_id` is request-scoped (see the property), so this can
+        # only ever be the calling user's own company.
+        if not url.endswith("companies/"):
+            company_id = self.company_id
+            if company_id:
+                logger.debug(f"Using company ID for request: {company_id}")
+                if "companyId" not in params:
+                    params["companyId"] = company_id
+
         # Sanitize parameters to prevent injection
         if params:
             sanitized_params = {}
@@ -287,15 +406,14 @@ class NormanAPI:
 
                 # OAuth mode: try to refresh the Norman token transparently
                 # using the refresh token we stored at code-exchange time.
+                # `refresh_norman_token_sync` rewrites the provider's mapping for
+                # this MCP token, so the retry re-resolves the fresh token
+                # per-request instead of us caching it on the shared client.
                 new_norman_token = self._refresh_oauth_norman_token()
                 if new_norman_token:
-                    self.access_token = new_norman_token
-                    self.token_source = "global"
                     return self._make_request(method, url, params, json_data, files)
 
                 logger.warning("Cannot refresh Norman token; client must reconnect")
-                self.access_token = None
-                from norman_mcp.context import set_api_token
                 set_api_token(None)
                 return {
                     "error": (
@@ -347,7 +465,6 @@ class NormanAPI:
         session see the new token.
         """
         try:
-            from norman_mcp.context import get_oauth_provider, set_api_token
             provider = get_oauth_provider()
             if provider is None:
                 return None

--- a/norman_mcp/context.py
+++ b/norman_mcp/context.py
@@ -1,13 +1,28 @@
+from contextvars import ContextVar
+from typing import Optional
+
 from mcp.server.fastmcp import Context
 
 # Re-export Context from mcp.server.fastmcp
 # This allows us to use norman_mcp.context.Context throughout the codebase
-# while maintaining a single source of truth 
+# while maintaining a single source of truth
 
-"""Context variables for the Norman MCP server."""
+"""Context variables for the Norman MCP server.
 
-# Global variable to store the OAuth provider across modules.
-# Set by server.create_app after the provider is constructed.
+SECURITY: the Norman access token and company id are **per-request** identity.
+They used to be plain module globals, which meant one user's token could be
+read by another user's concurrent request in the same process (one swarm
+replica + `--stateless` => every user shares one interpreter). That is a
+cross-tenant data leak, so they are ContextVars now: each ASGI request runs in
+its own task with its own copied context, so a write here is visible only to
+the request that made it.
+
+Do NOT turn these back into module globals, and do not cache a resolved token
+on a shared object (see `NormanAPI._resolve_norman_token`).
+"""
+
+# The OAuth provider is genuinely process-wide -- it owns the client/token
+# registry and holds no per-request identity -- so it stays a module global.
 oauth_provider = None
 
 def set_oauth_provider(provider):
@@ -19,27 +34,35 @@ def get_oauth_provider():
     """Get the global OAuth provider reference (may be None before startup)."""
     return oauth_provider
 
-# Global variable to store the API client
+# The API client instance. Stateless HTTP builds a fresh one per request via the
+# lifespan; SSE/stdio reuse one. Either way it must not carry identity state.
 _api_client = None
 
-# Global variables for direct API access
-_api_token = None
-_api_company_id = None
+# Per-request identity. Never make these module globals again.
+_api_token: ContextVar[Optional[str]] = ContextVar("norman_api_token", default=None)
+_api_company_id: ContextVar[Optional[str]] = ContextVar("norman_api_company_id", default=None)
 
 def set_api_client(client):
     """Set the global API client."""
     global _api_client
     _api_client = client
-    
+
 def get_api_client():
     """Get the global API client."""
     return _api_client
 
-def set_api_token(token):
-    """Set the global API token for all API calls."""
-    global _api_token
-    _api_token = token
-    
-def get_api_token():
-    """Get the global API token."""
-    return _api_token
+def set_api_token(token: Optional[str]) -> None:
+    """Set the Norman API token for the current request only."""
+    _api_token.set(token)
+
+def get_api_token() -> Optional[str]:
+    """Get the Norman API token for the current request."""
+    return _api_token.get()
+
+def set_api_company_id(company_id: Optional[str]) -> None:
+    """Cache the company id resolved for the current request only."""
+    _api_company_id.set(company_id)
+
+def get_api_company_id() -> Optional[str]:
+    """Get the company id resolved for the current request."""
+    return _api_company_id.get()

--- a/norman_mcp/server.py
+++ b/norman_mcp/server.py
@@ -211,11 +211,11 @@ async def authenticate_with_credentials(api_client):
             if not norman_token:
                 return False
             
-            api_client.set_token(norman_token)
-            
-            from norman_mcp.context import set_api_token
-            set_api_token(norman_token)
-            
+            # stdio: one process serves exactly one user, so the token belongs on
+            # the instance. (In OAuth mode it must stay request-scoped instead --
+            # see NormanAPI.set_token.)
+            api_client.set_token(norman_token, single_tenant=True)
+
             logger.info(f"✅ Authenticated: {norman_email}")
             return True
             

--- a/tests/test_tenant_isolation.py
+++ b/tests/test_tenant_isolation.py
@@ -1,0 +1,277 @@
+"""Cross-tenant isolation regression tests.
+
+Background: `_api_token` used to be a module global, and `NormanAPI._make_request`
+copied it onto the shared client instance (`self.access_token`). With one swarm
+replica serving every user in `--stateless` mode, two concurrent requests raced
+on that single global: user A's tool call could go out carrying user B's Norman
+bearer token, and the Norman API -- correctly scoping by the token's own user --
+returned B's company data to A.
+
+This exact defect was fixed once before and then reverted, with its test file
+deleted. These tests are the guard: if per-request identity moves back onto
+shared state, `test_concurrent_users_do_not_share_tokens` fails.
+
+Real threads and a real (loopback) HTTP server are used deliberately. Blocking
+tool calls run in a worker thread in production, and a fresh thread starts with
+an empty contextvars Context -- so ContextVar-backed identity isolates, while a
+module global does not. That difference is exactly what these tests assert.
+"""
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
+
+import pytest
+from mcp.server.auth.middleware.auth_context import auth_context_var
+from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
+from mcp.server.auth.provider import AccessToken
+
+from norman_mcp import context
+from norman_mcp.api import client as client_module
+from norman_mcp.api.client import NormanAPI
+
+# mcp token -> norman token, as the OAuth provider stores it
+TOKEN_MAP = {"mcp_a": "norman_a", "mcp_b": "norman_b"}
+
+
+@pytest.fixture(autouse=True)
+def disable_actual_api_calls():
+    """Override the global autouse fixture: these tests need real HTTP.
+
+    conftest patches `requests.request`, which is the call under test here. The
+    requests only ever reach a loopback stub started by the `fake_norman`
+    fixture.
+    """
+    yield
+
+
+class _FakeNormanHandler(BaseHTTPRequestHandler):
+    """Minimal stand-in for the Norman API that reports which token it saw."""
+
+    def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler API
+        auth = self.headers.get("Authorization", "")
+        token = auth.removeprefix("Bearer ").strip()
+        path = urlparse(self.path).path
+
+        self.server.seen.append((path, token))
+
+        if path == "/api/v1/companies/":
+            body = {"results": [{"publicId": f"company-of-{token}"}]}
+        else:
+            # Mirrors the real API: results follow the *token*, not the URL path
+            # (CompanyContextMixin resolves the company from request.user, and
+            # ignores the company_pk in the URL entirely).
+            body = {"results": [{"owner_token": token}], "path": path}
+
+        payload = json.dumps(body).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *args):  # silence test output
+        pass
+
+
+class _FakeProvider:
+    """Stands in for NormanOAuthProvider's token registry."""
+
+    def __init__(self, mapping):
+        self.token_mapping = dict(mapping)
+
+    def get_norman_token(self, mcp_token):
+        return self.token_mapping.get(mcp_token)
+
+
+@pytest.fixture
+def fake_norman():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _FakeNormanHandler)
+    server.seen = []
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@pytest.fixture
+def base_url(fake_norman):
+    host, port = fake_norman.server_address[:2]
+    return f"http://{host}:{port}/"
+
+
+@pytest.fixture
+def wired(fake_norman, base_url, monkeypatch):
+    """Point the client at the fake API and install the fake provider."""
+
+    class _Cfg:
+        api_base_url = base_url
+        NORMAN_API_TIMEOUT = 10
+
+    monkeypatch.setattr(client_module, "config", _Cfg())
+    monkeypatch.setattr(context, "oauth_provider", _FakeProvider(TOKEN_MAP))
+    return fake_norman
+
+
+def _enter_request(mcp_token, norman_token):
+    """Do what the SDK auth middleware + load_access_token do per request."""
+    auth_context_var.set(
+        AuthenticatedUser(
+            AccessToken(token=mcp_token, client_id="test-client", scopes=["read"])
+        )
+    )
+    context.set_api_token(norman_token)
+
+
+def _run_concurrently(bodies):
+    """Run each body in its own thread (= its own empty context), collect errors."""
+    errors = []
+
+    def guard(fn):
+        def wrapper():
+            try:
+                fn()
+            except BaseException as exc:  # surface in the main thread
+                errors.append(exc)
+
+        return wrapper
+
+    threads = [threading.Thread(target=guard(b)) for b in bodies]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    if errors:
+        raise errors[0]
+
+
+def test_concurrent_users_do_not_share_tokens(wired, base_url):
+    """Two users racing on one shared client must each use their OWN token.
+
+    The barrier forces the interleaving that used to lose the race: both users
+    publish their token before either performs its HTTP call. Under the old
+    module-global implementation, both outbound requests carried whichever token
+    was written last.
+    """
+    # One shared instance, as the SSE/stateful transports reuse.
+    api = NormanAPI(authenticate_on_init=False)
+    api.token_source = "oauth"
+
+    barrier = threading.Barrier(2)
+    results = {}
+
+    def one_user(mcp_token, norman_token):
+        def body():
+            _enter_request(mcp_token, norman_token)
+            # Both tokens are now published; whoever reads shared state loses.
+            barrier.wait(timeout=10)
+            results[mcp_token] = api._make_request(
+                "GET",
+                f"{base_url}api/v1/companies/{api.company_id}/accounting/transactions/",
+            )
+
+        return body
+
+    _run_concurrently([one_user("mcp_a", "norman_a"), one_user("mcp_b", "norman_b")])
+
+    assert results["mcp_a"]["results"][0]["owner_token"] == "norman_a", (
+        "user A's request went out with another user's token -- cross-tenant leak"
+    )
+    assert results["mcp_b"]["results"][0]["owner_token"] == "norman_b", (
+        "user B's request went out with another user's token -- cross-tenant leak"
+    )
+
+
+def test_company_id_is_not_pinned_across_users(wired):
+    """company_id must be resolved per request, not pinned by the first caller."""
+    api = NormanAPI(authenticate_on_init=False)
+    api.token_source = "oauth"
+
+    barrier = threading.Barrier(2)
+    seen = {}
+
+    def one_user(mcp_token, norman_token):
+        def body():
+            _enter_request(mcp_token, norman_token)
+            barrier.wait(timeout=10)
+            seen[mcp_token] = api.company_id
+
+        return body
+
+    _run_concurrently([one_user("mcp_a", "norman_a"), one_user("mcp_b", "norman_b")])
+
+    assert seen["mcp_a"] == "company-of-norman_a"
+    assert seen["mcp_b"] == "company-of-norman_b"
+
+
+def test_request_identity_never_cached_on_shared_instance(wired, base_url):
+    """A completed OAuth request must leave no identity behind on the client."""
+    api = NormanAPI(authenticate_on_init=False)
+    api.token_source = "oauth"
+
+    def body():
+        _enter_request("mcp_a", "norman_a")
+        api._make_request(
+            "GET", f"{base_url}api/v1/companies/x/accounting/transactions/"
+        )
+
+    _run_concurrently([body])
+
+    assert api.access_token is None, (
+        "request token was cached on the shared client -- this is the leak vector"
+    )
+    assert api._env_company_id is None, (
+        "request company id was cached on the shared client"
+    )
+
+
+def test_single_tenant_stdio_token_still_works(wired, base_url):
+    """stdio/env mode keeps its token on the instance across tasks and threads.
+
+    Guards the flip side of the fix: making OAuth identity request-scoped must
+    not break the single-user stdio deployment, where there is no auth context
+    and no per-request token to resolve from.
+    """
+    api = NormanAPI(authenticate_on_init=False)
+    api.set_token("norman_solo", single_tenant=True)
+
+    assert api.token_source == "env"
+    assert api.company_id == "company-of-norman_solo"
+
+    out = {}
+
+    def body():  # a different thread => a fresh, empty context
+        out["res"] = api._make_request(
+            "GET", f"{base_url}api/v1/companies/x/accounting/transactions/"
+        )
+
+    _run_concurrently([body])
+
+    assert out["res"]["results"][0]["owner_token"] == "norman_solo"
+
+
+def test_unauthenticated_request_gets_no_token(wired, base_url):
+    """With no auth context and no request-scoped token, refuse to call the API.
+
+    Guards the other half of the bug: falling back to leftover shared state when
+    the caller's own identity is missing.
+    """
+    api = NormanAPI(authenticate_on_init=False)
+    api.token_source = "oauth"
+
+    result = {}
+
+    def body():
+        # No _enter_request(): no auth context, no request token.
+        result["out"] = api._make_request(
+            "GET", f"{base_url}api/v1/companies/x/accounting/transactions/"
+        )
+
+    _run_concurrently([body])
+
+    assert "error" in result["out"]
+    assert wired.seen == [], "made an API call without a caller identity"


### PR DESCRIPTION
Resolves the Norman access token and company id per request instead of holding
them in module globals and caching them on the shared `NormanAPI` instance.

- `context.py` — `_api_token` / `_api_company_id` become `ContextVar`s.
- `client.py` — `_resolve_norman_token()` derives the token from the request's
  own auth context (`get_access_token()` → `provider.get_norman_token`) on every
  call and keeps it in a local; `company_id` is a request-scoped property; the
  401 transparent-refresh path is request-scoped as well.
- `server.py` — stdio passes `set_token(..., single_tenant=True)`; that
  deployment serves one user and has no auth context to resolve from.

### Tests

`tests/test_tenant_isolation.py` — 5 tests using real threads and a loopback API
stub, covering concurrent callers, company-id resolution, the single-tenant stdio
path, and the no-identity case. Verified to fail before this change and pass after.

Full suite: 21 passed (`tests/test_basic.py` is excluded — it is broken on `main`
independently, it imports a `Config` symbol that no longer exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
