### PR TITLE
fix: validate OAuth redirect URIs against a server-level allow-list

### DIFF
--- a/norman_mcp/auth/provider.py
+++ b/norman_mcp/auth/provider.py
@@ -38,6 +38,7 @@ from mcp.server.auth.provider import (
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 
 from norman_mcp.config.settings import config
+from norman_mcp.security.redirects import is_allowed_redirect_uri
 
 logger = logging.getLogger(__name__)
 
@@ -292,6 +293,9 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
     
     def add_redirect_uri(self, client_id: str, redirect_uri: str) -> None:
         """Add a redirect URI to an existing client (for dynamic registration)."""
+        if not is_allowed_redirect_uri(redirect_uri):
+            logger.warning(f"Refusing to add disallowed redirect URI for {client_id[:8]}: {redirect_uri}")
+            return
         client = self.clients.get(client_id)
         if client and redirect_uri not in [str(uri) for uri in client.redirect_uris]:
             # Create new client with updated redirect URIs
@@ -310,7 +314,28 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
             self._save_state()
 
     async def register_client(self, client_info: OAuthClientInformationFull) -> None:
-        """Register a new OAuth client via Dynamic Client Registration."""
+        """Register a new OAuth client via Dynamic Client Registration.
+
+        Open DCR is intentional (MCP clients self-register), but we drop any
+        redirect URI that is not on the server allow-list so an attacker cannot
+        persist a code-exfiltration target. The authoritative check still runs
+        per /authorize request via validate_redirect_uri.
+        """
+        allowed_uris = [u for u in (client_info.redirect_uris or []) if is_allowed_redirect_uri(str(u))]
+        dropped = [str(u) for u in (client_info.redirect_uris or []) if not is_allowed_redirect_uri(str(u))]
+        if dropped:
+            logger.warning(f"DCR for {client_info.client_id}: dropping disallowed redirect_uris: {dropped}")
+        if list(allowed_uris) != list(client_info.redirect_uris or []):
+            client_info = OAuthClientInformationFull(
+                client_id=client_info.client_id,
+                client_name=client_info.client_name,
+                client_secret=client_info.client_secret,
+                redirect_uris=allowed_uris,
+                token_endpoint_auth_method=client_info.token_endpoint_auth_method or "none",
+                grant_types=client_info.grant_types or ["authorization_code", "refresh_token"],
+                response_types=client_info.response_types or ["code"],
+                scope=client_info.scope,
+            )
         if not client_info.scope or not any(s in client_info.scope for s in SUPPORTED_SCOPES):
             client_info = OAuthClientInformationFull(
                 client_id=client_info.client_id,

--- a/norman_mcp/security/redirects.py
+++ b/norman_mcp/security/redirects.py
@@ -1,0 +1,95 @@
+"""Redirect URI allow-listing for the MCP authorization server.
+
+Norman's MCP server is a *delegated* OAuth Authorization Server: it sends the
+user to Norman's real OAuth server to authenticate, then redirects the issued
+authorization code back to the client's ``redirect_uri``. Because the consent
+the user sees lives on Norman's domain (and only ever shows the legitimate
+``mcp.norman.finance/oauth/callback`` destination), the user has no way to see
+the *final* redirect target. If we accepted arbitrary ``redirect_uri`` values,
+an attacker could register a client pointing at their own server, phish a victim
+through the otherwise-trustworthy Norman consent flow, and receive an
+authorization code that maps to the victim's Norman token — full account
+takeover.
+
+To close that path we only allow redirect targets that are actually used by
+legitimate MCP clients:
+
+* HTTP loopback (localhost / 127.0.0.1 / [::1]) on any port — RFC 8252 §7.3,
+  needed by native clients and the MCP Inspector that bind random local ports.
+* Custom (non-http) schemes — native-app deep links (e.g. ``cursor://``).
+* HTTPS only for an explicit host allow-list (known connector origins),
+  extensible via the ``NORMAN_MCP_ALLOWED_REDIRECT_HOSTS`` env var.
+
+Everything else — notably plain ``https://attacker.com/...`` — is rejected.
+"""
+
+import logging
+import os
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+# HTTPS redirect hosts that ship as allowed by default. These are the origins
+# of the MCP clients we actually support (and Norman's own callback host).
+# Matching is exact host OR a subdomain of one of these (e.g. mcp.norman.finance
+# matches "norman.finance").
+_DEFAULT_ALLOWED_HTTPS_HOSTS = {
+    "norman.finance",
+    "chatgpt.com",
+    "claude.ai",
+    "claude.com",
+}
+
+_LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
+
+
+def _allowed_https_hosts() -> set[str]:
+    """Return the configured HTTPS host allow-list (defaults + env extension)."""
+    hosts = set(_DEFAULT_ALLOWED_HTTPS_HOSTS)
+    extra = os.environ.get("NORMAN_MCP_ALLOWED_REDIRECT_HOSTS", "")
+    for host in extra.split(","):
+        host = host.strip().lower()
+        if host:
+            hosts.add(host)
+    return hosts
+
+
+def _host_is_allowed(host: str) -> bool:
+    host = (host or "").lower()
+    if not host:
+        return False
+    for allowed in _allowed_https_hosts():
+        if host == allowed or host.endswith("." + allowed):
+            return True
+    return False
+
+
+def is_allowed_redirect_uri(uri: str) -> bool:
+    """Return True if ``uri`` is an acceptable OAuth redirect target.
+
+    Used both at Dynamic Client Registration time and (authoritatively) when
+    validating the ``redirect_uri`` on an /authorize request.
+    """
+    if not uri:
+        return False
+    try:
+        parsed = urlparse(str(uri))
+    except Exception:
+        return False
+
+    scheme = (parsed.scheme or "").lower()
+    host = (parsed.hostname or "").lower()
+
+    if scheme == "http":
+        # Only loopback HTTP is acceptable (RFC 8252). Any other HTTP host is
+        # rejected — both because it is an insecure transport and because a
+        # remote HTTP host is a valid code-exfiltration target.
+        return host in _LOOPBACK_HOSTS
+    if scheme == "https":
+        return _host_is_allowed(host)
+    if scheme and scheme not in ("http", "https"):
+        # Custom scheme: native-app deep link (cursor://, vscode://, ...).
+        # These can only be intercepted by a handler installed on the user's own
+        # machine, so they are not a remote-exfiltration vector.
+        return True
+    return False

--- a/norman_mcp/server.py
+++ b/norman_mcp/server.py
@@ -75,38 +75,33 @@ def patched_build_metadata(*args, **kwargs):
     return metadata
 mcp.server.auth.routes.build_metadata = patched_build_metadata
 
-# Patch to accept dynamic redirect URIs (Cursor, Inspector use random ports)
+# Patch redirect-URI validation to an allow-list (Cursor, Inspector use random
+# loopback ports; ChatGPT/Claude use known HTTPS origins). This is the
+# authoritative gate against authorization-code phishing: the SDK calls it on
+# every /authorize request *before* the provider's authorize() runs, so an
+# attacker-controlled redirect (e.g. https://attacker.com/steal) is rejected
+# here regardless of what redirect_uris a client self-registered via DCR.
 from mcp.shared.auth import OAuthClientInformationFull, InvalidRedirectUriError
-
-_original_validate_redirect_uri = OAuthClientInformationFull.validate_redirect_uri
+from norman_mcp.security.redirects import is_allowed_redirect_uri
 
 def _flexible_validate_redirect_uri(self, redirect_uri):
-    """Accept redirect URIs dynamically for MCP clients.
+    """Validate a redirect URI against the server-level allow-list.
 
-    Security model:
-    - HTTPS URIs: always accepted (PKCE is enforced by MCP SDK via S256)
-    - Custom schemes (cursor://, etc.): always accepted (native app deep links)
-    - HTTP loopback (localhost/127.0.0.1/[::1]): accepted per RFC 8252 §7.3
-    - HTTP non-loopback: rejected (insecure transport to remote host)
+    Security model (see norman_mcp.security.redirects):
+    - HTTP loopback (localhost/127.0.0.1/[::1], any port): accepted per RFC 8252
+    - Custom schemes (cursor://, etc.): accepted (native-app deep links)
+    - HTTPS: accepted ONLY for allow-listed connector hosts
+    - Everything else (incl. https to arbitrary hosts): rejected
+
+    Note: we deliberately do NOT trust the client's own registered redirect_uris
+    here — with open Dynamic Client Registration an attacker controls that list,
+    so the only meaningful check is the server-level allow-list above.
     """
     if redirect_uri is not None:
         uri_str = str(redirect_uri)
-        # HTTPS is always safe — PKCE prevents code interception
-        if uri_str.startswith("https://"):
+        if is_allowed_redirect_uri(uri_str):
             return redirect_uri
-        # Custom schemes for native apps (e.g. cursor://anysphere.cursor)
-        if "://" in uri_str and not uri_str.startswith("http://"):
-            return redirect_uri
-        # RFC 8252 §7.3: HTTP loopback with dynamic ports is safe with PKCE
-        loopback_prefixes = [
-            "http://localhost:", "http://localhost/",
-            "http://127.0.0.1:", "http://127.0.0.1/",
-            "http://[::1]:", "http://[::1]/",
-        ]
-        if any(uri_str.startswith(p) for p in loopback_prefixes):
-            return redirect_uri
-        # Reject plain HTTP to non-loopback hosts
-        return _original_validate_redirect_uri(self, redirect_uri)
+        raise InvalidRedirectUriError(f"redirect_uri not allowed: {uri_str}")
     elif self.redirect_uris is not None and len(self.redirect_uris) == 1:
         return self.redirect_uris[0]
     else:

--- a/tests/test_redirect_allowlist.py
+++ b/tests/test_redirect_allowlist.py
@@ -1,0 +1,65 @@
+"""Redirect-URI allow-list tests (OAuth authorization-code phishing defense)."""
+
+import pytest
+
+from norman_mcp.security.redirects import is_allowed_redirect_uri
+
+
+def test_rejects_external_https():
+    # The reported attack: attacker-controlled HTTPS exfiltration target.
+    assert is_allowed_redirect_uri("https://attacker.com/steal") is False
+    assert is_allowed_redirect_uri("https://norman.finance.attacker.com/cb") is False
+
+
+def test_allows_known_connector_https_hosts():
+    assert is_allowed_redirect_uri("https://chatgpt.com/connector_platform_oauth_redirect")
+    assert is_allowed_redirect_uri("https://claude.ai/api/mcp/auth_callback")
+    # Subdomain of an allow-listed base domain.
+    assert is_allowed_redirect_uri("https://mcp.norman.finance/oauth/callback")
+
+
+def test_allows_http_loopback_any_port():
+    assert is_allowed_redirect_uri("http://localhost:6274/oauth/callback")
+    assert is_allowed_redirect_uri("http://127.0.0.1:51763/callback")
+    assert is_allowed_redirect_uri("http://[::1]:6274/cb")
+
+
+def test_rejects_plain_http_to_remote_host():
+    assert is_allowed_redirect_uri("http://attacker.com/steal") is False
+
+
+def test_allows_custom_native_scheme():
+    assert is_allowed_redirect_uri("cursor://anysphere.cursor/callback")
+
+
+def test_env_extension_adds_hosts(monkeypatch):
+    monkeypatch.setenv("NORMAN_MCP_ALLOWED_REDIRECT_HOSTS", "partner.example, other.test")
+    assert is_allowed_redirect_uri("https://partner.example/cb")
+    assert is_allowed_redirect_uri("https://api.partner.example/cb")
+    assert is_allowed_redirect_uri("https://other.test/cb")
+
+
+def test_empty_or_garbage_rejected():
+    assert is_allowed_redirect_uri("") is False
+    assert is_allowed_redirect_uri("not a url") is False
+
+
+def test_sdk_validate_patch_enforces_allowlist():
+    """Importing the server monkeypatches the SDK validator to the allow-list.
+
+    Critically, this rejects a disallowed URI even when the client has it in its
+    own registered redirect_uris (open DCR lets an attacker self-register it).
+    """
+    import norman_mcp.server  # noqa: F401  (applies the monkeypatch on import)
+    from mcp.shared.auth import OAuthClientInformationFull, InvalidRedirectUriError
+
+    fn = OAuthClientInformationFull.validate_redirect_uri
+
+    class _DummyClient:
+        # Even though the attacker "registered" attacker.com, it must be rejected.
+        redirect_uris = ["https://attacker.com/steal"]
+
+    with pytest.raises(InvalidRedirectUriError):
+        fn(_DummyClient(), "https://attacker.com/steal")
+
+    assert fn(_DummyClient(), "https://chatgpt.com/cb") == "https://chatgpt.com/cb"


### PR DESCRIPTION
`_flexible_validate_redirect_uri` accepted any `https://` redirect target. The
stated rationale ("PKCE prevents code interception") does not hold here: Dynamic
Client Registration is open by design, so a client can register itself with any
redirect_uri and supply its own PKCE verifier. Per-client redirect lists are not
a control either, for the same reason — the check has to be server-level.

Adds `norman_mcp/security/redirects.py`:

- HTTP loopback on any port — RFC 8252 §7.3, for native clients and the Inspector.
- Custom non-http schemes — native-app deep links (`cursor://`, `vscode://`).
- HTTPS only for known connector hosts, extensible via
  `NORMAN_MCP_ALLOWED_REDIRECT_HOSTS`.

Enforced in two places: `validate_redirect_uri` (authoritative — the SDK calls it
on every `/authorize` before `provider.authorize()` runs) and at DCR, where
`register_client` / `add_redirect_uri` drop non-allowed URIs so none get persisted.

### Verified

Real client redirect URIs all still pass — `claude.ai`, `claude.com`,
`chatgpt.com/connector/oauth/{id}`, `chatgpt.com/connector_platform_oauth_redirect`,
`mcp.norman.finance`, loopback on random ports, `cursor://`. Suffix-confusion is
rejected (`https://claude.ai.attacker.com` → denied).

`tests/test_redirect_allowlist.py` — 8 tests. Full suite green (24 passed;
`tests/test_basic.py` excluded, it is broken on `main` independently).

### Before deploying

Dynamically-registered clients whose redirect_uri is an HTTPS host outside the
list will stop working — that is the intent, but enumerate them from the OAuth
state file first and add any legitimate hosts to
`NORMAN_MCP_ALLOWED_REDIRECT_HOSTS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
