### PR TITLE
ci: do not let Sentry release bookkeeping block the deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,13 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
 
+      # Release bookkeeping must never gate the deploy. A transient Sentry API
+      # error (SSL reset, 5xx) used to skip "update mcp server image" entirely,
+      # so a green build sat in the registry while prod kept running the old
+      # image — including when the deploy was carrying a security fix.
       - name: draft sentry release
         uses: getsentry/action-release@v1
+        continue-on-error: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
@@ -85,6 +90,7 @@ jobs:
 
       - name: finalize sentry release
         uses: getsentry/action-release@v1
+        continue-on-error: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}


### PR DESCRIPTION
[Run 30267877837](https://github.com/norman-finance/norman-mcp-server/actions/runs/30267877837)
failed at `draft sentry release`:

```
error: API request failed
Caused by:
    [35] SSL connect error (Recv failure: Connection reset by peer)
```

That step sits ahead of `update mcp server image`, so the failure skipped the
deploy entirely — `read image identifiers`, `update mcp server image` and
`finalize sentry release` were all skipped. The image was built and pushed to
ghcr, CI went red, and production kept serving the previous image. The commit in
question was carrying the token-isolation and redirect-allowlist fixes.

Rerunning the same commit deployed it unchanged, which confirms the error was
transient network flakiness rather than a bad `SENTRY_AUTH_TOKEN`.

Both Sentry steps become `continue-on-error: true`. Release metadata is
observability, not a deployment precondition, and this failure mode is worst
exactly when it matters most: it silently withholds a deploy that is carrying a
fix, while looking like an ordinary red build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
