### PR TITLE
fix: persist the active company per MCP token

### DIFF
--- a/norman_mcp/api/client.py
+++ b/norman_mcp/api/client.py
@@ -41,8 +41,13 @@ class NormanAPI:
     def company_id(self) -> Optional[str]:
         """The company id for the CURRENT request.
 
-        Resolved from the requesting user's own token, cached per request. It is
-        deliberately never a plain attribute in OAuth mode: a shared attribute
+        Resolution order, all scoped to the calling user:
+        1. The request-scoped ContextVar (seeded by `load_access_token` from the
+           caller's own saved selection, or by an earlier lookup this request).
+        2. The caller's persisted `switch_company` choice, by MCP token.
+        3. The user's first company from the API.
+
+        Deliberately never a plain attribute in OAuth mode: a shared attribute
         pinned whichever company happened to be looked up first and handed it to
         every later caller.
         """
@@ -52,6 +57,13 @@ class NormanAPI:
         cached = get_api_company_id()
         if cached:
             return cached
+
+        # A selection persisted by switch_company outlives the request that made
+        # it, so pick it up before falling back to "first company".
+        persisted = self._persisted_company_id()
+        if persisted:
+            set_api_company_id(persisted)
+            return persisted
 
         token = self._resolve_norman_token()
         if not token:
@@ -66,8 +78,42 @@ class NormanAPI:
     def company_id(self, value: Optional[str]) -> None:
         if self.token_source == "env":
             self._env_company_id = value
-        else:
-            set_api_company_id(value)
+            return
+
+        set_api_company_id(value)
+
+        # Persist for this caller's later requests. Only the explicit selection
+        # path reaches here (switch_company -> set_company); the lazy "first
+        # company" lookup above deliberately does not persist, so a default is
+        # never mistaken for a choice.
+        mcp_token = self._current_mcp_token()
+        provider = get_oauth_provider()
+        if mcp_token and provider is not None:
+            try:
+                provider.set_company_for_token(mcp_token, value)
+            except Exception as e:
+                logger.error(f"Could not persist company selection: {e}")
+
+    @staticmethod
+    def _current_mcp_token() -> Optional[str]:
+        """The MCP token of the request being served, if there is one."""
+        try:
+            access_token = get_access_token()
+        except Exception:
+            return None
+        return getattr(access_token, "token", None) if access_token else None
+
+    def _persisted_company_id(self) -> Optional[str]:
+        """The company this caller previously selected via switch_company."""
+        mcp_token = self._current_mcp_token()
+        provider = get_oauth_provider()
+        if not mcp_token or provider is None:
+            return None
+        try:
+            return provider.get_company_for_token(mcp_token)
+        except Exception as e:
+            logger.error(f"Could not read persisted company selection: {e}")
+            return None
 
     def _resolve_norman_token(self) -> Optional[str]:
         """Resolve the Norman access token for the CURRENT request.
@@ -172,15 +218,11 @@ class NormanAPI:
         # re-derives it per call from the request's own auth context.
         set_api_token(token)
 
-        # Resolve the company for THIS request's token. Previously guarded by
-        # `if not self.company_id`, which pinned the first user's company onto
-        # the shared client and handed it to everyone who came after.
-        try:
-            company_id = self._fetch_company_id(token)
-            if company_id:
-                set_api_company_id(company_id)
-        except Exception as e:
-            logger.error(f"Error setting company ID with OAuth token: {str(e)}")
+        # The company is NOT resolved here on purpose. `load_access_token` has
+        # already seeded this caller's saved switch_company selection, and an
+        # eager lookup would overwrite it with their first company. The
+        # `company_id` property resolves lazily instead -- which also spares an
+        # API round trip on requests that never need a company.
 
 
     def authenticate(self) -> None:

--- a/norman_mcp/auth/provider.py
+++ b/norman_mcp/auth/provider.py
@@ -85,6 +85,11 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
 
         self.state_mapping: Dict[str, Dict[str, Any]] = {}
         self.token_mapping: Dict[str, str] = {}
+        # Active company per MCP token. Keyed by the caller's own MCP token, so
+        # one user's selection can never be observed by another -- unlike the old
+        # `NormanAPI.company_id` attribute, which was shared process-wide and was
+        # both how switch_company "persisted" and how companies leaked.
+        self.token_to_company_id: Dict[str, str] = {}
 
         self._persist_lock = threading.Lock()
         self._load_state()
@@ -140,6 +145,7 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
                     "refresh_tokens": refresh_ser,
                     "tokens": tokens_ser,
                     "token_mapping": self.token_mapping,
+                    "token_to_company_id": self.token_to_company_id,
                 }
 
                 tmp = path.with_suffix(".tmp")
@@ -203,6 +209,7 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
                     )
 
             self.token_mapping = data.get("token_mapping", {})
+            self.token_to_company_id = data.get("token_to_company_id", {})
             logger.info(
                 "Restored OAuth state: %d clients, %d refresh tokens, %d access tokens",
                 len(self.clients), len(self.refresh_tokens), len(self.tokens),
@@ -567,15 +574,26 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
             del self.tokens[token]
             if token in self.token_mapping:
                 del self.token_mapping[token]
+            if token in self.token_to_company_id:
+                del self.token_to_company_id[token]
             self._save_state()
             return None
-        
-        # Set Norman token in context when validating
+
+        # Seed the per-request context from THIS caller's own token. Both values
+        # are request-scoped ContextVars (see norman_mcp.context) -- never write
+        # caller identity anywhere process-wide.
+        from norman_mcp.context import set_api_company_id, set_api_token
+
         norman_token = self.token_mapping.get(token)
         if norman_token:
-            from norman_mcp.context import set_api_token
             set_api_token(norman_token)
-        
+
+        # Restore the company this caller last selected via switch_company. Keyed
+        # by their MCP token, so it cannot be observed by anyone else.
+        company_id = self.token_to_company_id.get(token)
+        if company_id:
+            set_api_company_id(company_id)
+
         return access_token
 
     async def load_refresh_token(
@@ -644,6 +662,11 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
                     new_norman_refresh or self.token_mapping.get(refresh_token.token)
                 )
                 
+                # Known limitation: the company selected via switch_company is
+                # keyed by MCP access token, so a refresh (>=24h) drops back to
+                # the caller's default company. Carrying it over would need a
+                # session identity spanning token rotations, which the provider
+                # does not have -- deliberately not invented here.
                 logger.info(f"✅ Refreshed MCP token: {new_mcp_token[:15]}...")
                 self._save_state()
 
@@ -665,6 +688,8 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
         if token in self.tokens:
             if token in self.token_mapping:
                 del self.token_mapping[token]
+            if token in self.token_to_company_id:
+                del self.token_to_company_id[token]
             del self.tokens[token]
             logger.info(f"Revoked access token: {token[:10]}...")
             changed = True
@@ -680,6 +705,33 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
     def get_norman_token(self, mcp_token: str) -> Optional[str]:
         """Get the Norman API token for a given MCP token."""
         return self.token_mapping.get(mcp_token)
+
+    def get_company_for_token(self, mcp_token: str) -> Optional[str]:
+        """Get the company this MCP token last selected, if any."""
+        return self.token_to_company_id.get(mcp_token)
+
+    def set_company_for_token(self, mcp_token: str, company_id: Optional[str]) -> None:
+        """Remember the active company for one MCP token.
+
+        Keyed by the caller's own token, so a selection is visible only to the
+        caller -- this is what lets switch_company outlive a single request
+        without reintroducing shared mutable company state.
+
+        The caller's access to `company_id` must already have been verified;
+        this only persists the choice. See tools/tax_advisor.switch_company,
+        which confirms the company is reachable before calling this.
+        """
+        if not mcp_token:
+            return
+        if company_id:
+            if self.token_to_company_id.get(mcp_token) == company_id:
+                return
+            self.token_to_company_id[mcp_token] = company_id
+        elif mcp_token in self.token_to_company_id:
+            del self.token_to_company_id[mcp_token]
+        else:
+            return
+        self._save_state()
 
     def refresh_norman_token_sync(self, mcp_token: str) -> Optional[str]:
         """Refresh the Norman access token for an MCP access token (sync).

--- a/norman_mcp/tools/tax_advisor.py
+++ b/norman_mcp/tools/tax_advisor.py
@@ -414,23 +414,36 @@ def register_tax_advisor_tools(mcp):
         api = ctx.request_context.lifespan_context["api"]
         previous_id = api.company_id
 
-        api.set_company(company_id)
-
+        # Confirm the caller can actually reach this company BEFORE recording the
+        # selection. The endpoint is scoped by the requesting user server-side
+        # (Company.objects.for_user), so a company they have no access to comes
+        # back as an error. Persisting first would let a caller pin an arbitrary
+        # company id onto their own session, and that id is sent as the `company`
+        # field when creating transactions.
         company_url = urljoin(config.api_base_url, f"api/v1/companies/{company_id}/")
         try:
             company = api._make_request("GET", company_url)
-            return {
-                "previousCompanyId": previous_id,
-                "activeCompanyId": company_id,
-                "company": {
-                    "name": company.get("name"),
-                    "accountType": company.get("accountType"),
-                    "isSme": company.get("isSme"),
-                },
-            }
         except Exception as e:
             return {
                 "previousCompanyId": previous_id,
-                "activeCompanyId": company_id,
-                "warning": f"Switched, but could not fetch company details: {e}",
+                "error": f"Could not switch to {company_id}: {e}",
             }
+
+        if not isinstance(company, dict) or company.get("error"):
+            detail = company.get("error") if isinstance(company, dict) else "unexpected response"
+            return {
+                "previousCompanyId": previous_id,
+                "error": f"Could not switch to {company_id}: {detail}",
+            }
+
+        api.set_company(company_id)
+
+        return {
+            "previousCompanyId": previous_id,
+            "activeCompanyId": company_id,
+            "company": {
+                "name": company.get("name"),
+                "accountType": company.get("accountType"),
+                "isSme": company.get("isSme"),
+            },
+        }

--- a/tests/test_company_selection.py
+++ b/tests/test_company_selection.py
@@ -1,0 +1,287 @@
+"""Per-caller persistence of the active company (switch_company).
+
+`switch_company` promises that "all subsequent tool calls will operate on the
+selected company". It used to keep that promise by writing `company_id` onto the
+shared `NormanAPI` instance -- the same shared mutable state that leaked
+companies between users, and which stopped persisting at all once the client
+became per-request.
+
+The selection now lives in `NormanOAuthProvider.token_to_company_id`, keyed by
+the caller's own MCP token. These tests pin down both halves: it survives across
+requests for the caller, and it is invisible to everyone else.
+"""
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
+
+import pytest
+from mcp.server.auth.middleware.auth_context import auth_context_var
+from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
+from mcp.server.auth.provider import AccessToken
+
+from norman_mcp import context
+from norman_mcp.api import client as client_module
+from norman_mcp.api.client import NormanAPI
+
+TOKEN_MAP = {"mcp_a": "norman_a", "mcp_b": "norman_b"}
+
+
+@pytest.fixture(autouse=True)
+def disable_actual_api_calls():
+    """Override the global autouse fixture: these tests need real HTTP."""
+    yield
+
+
+class _FakeNormanHandler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler API
+        token = self.headers.get("Authorization", "").removeprefix("Bearer ").strip()
+        path = urlparse(self.path).path
+        self.server.seen.append((path, token))
+
+        # Companies the caller has no access to: the real API scopes the detail
+        # endpoint by request.user, so an unreachable company 404s.
+        denied = getattr(self.server, "deny", set())
+        if any(f"/companies/{d}/" in path for d in denied):
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+
+        if path == "/api/v1/companies/":
+            body = {"results": [{"publicId": f"default-of-{token}"}]}
+        else:
+            body = {"results": [{"owner_token": token}], "path": path}
+
+        payload = json.dumps(body).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *args):
+        pass
+
+
+class _FakeProvider:
+    """Stands in for NormanOAuthProvider's token + company registry."""
+
+    def __init__(self, mapping):
+        self.token_mapping = dict(mapping)
+        self.token_to_company_id = {}
+        self.saves = 0
+
+    def get_norman_token(self, mcp_token):
+        return self.token_mapping.get(mcp_token)
+
+    def get_company_for_token(self, mcp_token):
+        return self.token_to_company_id.get(mcp_token)
+
+    def set_company_for_token(self, mcp_token, company_id):
+        if not mcp_token:
+            return
+        if company_id:
+            if self.token_to_company_id.get(mcp_token) == company_id:
+                return
+            self.token_to_company_id[mcp_token] = company_id
+        elif mcp_token in self.token_to_company_id:
+            del self.token_to_company_id[mcp_token]
+        else:
+            return
+        self.saves += 1
+
+
+@pytest.fixture
+def fake_norman():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _FakeNormanHandler)
+    server.seen = []
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@pytest.fixture
+def provider(fake_norman, monkeypatch):
+    host, port = fake_norman.server_address[:2]
+
+    class _Cfg:
+        api_base_url = f"http://{host}:{port}/"
+        NORMAN_API_TIMEOUT = 10
+
+    prov = _FakeProvider(TOKEN_MAP)
+    monkeypatch.setattr(client_module, "config", _Cfg())
+    monkeypatch.setattr(context, "oauth_provider", prov)
+    return prov
+
+
+def _serve_request(api, provider, mcp_token, norman_token, body):
+    """Run `body` in a fresh thread == a fresh request context.
+
+    Mirrors the real request path: the auth middleware seeds the token, then
+    `load_access_token` seeds any saved company selection for this caller.
+    """
+    result = {}
+    errors = []
+
+    def run():
+        try:
+            auth_context_var.set(
+                AuthenticatedUser(
+                    AccessToken(token=mcp_token, client_id="c", scopes=["read"])
+                )
+            )
+            context.set_api_token(norman_token)
+            saved = provider.get_company_for_token(mcp_token)
+            if saved:
+                context.set_api_company_id(saved)
+            result["value"] = body()
+        except BaseException as exc:
+            errors.append(exc)
+
+    t = threading.Thread(target=run)
+    t.start()
+    t.join(timeout=30)
+    if errors:
+        raise errors[0]
+    return result.get("value")
+
+
+def test_selection_survives_the_next_request(provider):
+    """A switch in request 1 is still active in request 2."""
+    api = NormanAPI(authenticate_on_init=False)
+    api.token_source = "oauth"
+
+    _serve_request(api, provider, "mcp_a", "norman_a", lambda: api.set_company("CO-CHOSEN"))
+    later = _serve_request(api, provider, "mcp_a", "norman_a", lambda: api.company_id)
+
+    assert later == "CO-CHOSEN", "switch_company did not outlive the request"
+
+
+def test_selection_is_not_visible_to_another_user(provider):
+    """One caller's switch must not change anyone else's active company."""
+    api = NormanAPI(authenticate_on_init=False)
+    api.token_source = "oauth"
+
+    _serve_request(api, provider, "mcp_a", "norman_a", lambda: api.set_company("CO-OF-A"))
+
+    b_sees = _serve_request(api, provider, "mcp_b", "norman_b", lambda: api.company_id)
+    a_sees = _serve_request(api, provider, "mcp_a", "norman_a", lambda: api.company_id)
+
+    assert b_sees == "default-of-norman_b", "user B inherited another user's selection"
+    assert a_sees == "CO-OF-A"
+
+
+def test_concurrent_switches_do_not_cross(provider):
+    """Two users switching at the same time keep their own selections."""
+    api = NormanAPI(authenticate_on_init=False)
+    api.token_source = "oauth"
+
+    barrier = threading.Barrier(2)
+
+    def switcher(mcp_token, norman_token, company):
+        def body():
+            def inner():
+                barrier.wait(timeout=10)
+                return api.set_company(company)
+
+            return _serve_request(api, provider, mcp_token, norman_token, inner)
+
+        return body
+
+    threads = [
+        threading.Thread(target=switcher("mcp_a", "norman_a", "CO-A")),
+        threading.Thread(target=switcher("mcp_b", "norman_b", "CO-B")),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert provider.token_to_company_id == {"mcp_a": "CO-A", "mcp_b": "CO-B"}
+
+
+def test_default_company_is_not_persisted_as_a_choice(provider):
+    """The lazy "first company" fallback must not look like a switch.
+
+    Otherwise the first request would freeze the caller's default company into
+    the state file, and a later change of their default would never be picked up.
+    """
+    api = NormanAPI(authenticate_on_init=False)
+    api.token_source = "oauth"
+
+    resolved = _serve_request(api, provider, "mcp_a", "norman_a", lambda: api.company_id)
+
+    assert resolved == "default-of-norman_a"
+    assert provider.token_to_company_id == {}, "a default was persisted as a selection"
+    assert provider.saves == 0
+
+
+def test_switch_company_does_not_persist_a_company_it_cannot_reach(provider, fake_norman):
+    """An inaccessible company must not be recorded as the active one.
+
+    The company id is sent as the `company` field when creating transactions, so
+    pinning an arbitrary one onto your own session must not be possible. The
+    server scopes /companies/{id}/ by the requesting user, and the tool has to
+    respect that answer before persisting.
+    """
+    import asyncio
+
+    from mcp.server.fastmcp import FastMCP
+
+    from norman_mcp.tools import tax_advisor as tax_advisor_module
+    from norman_mcp.tools.tax_advisor import register_tax_advisor_tools
+
+    # The tool builds URLs from its own module-level config import.
+    monkey_cfg = client_module.config
+    original = tax_advisor_module.config
+    tax_advisor_module.config = monkey_cfg
+
+    srv = FastMCP()
+    register_tax_advisor_tools(srv)
+    switch_company = srv._tool_manager._tools["switch_company"].fn
+
+    api = NormanAPI(authenticate_on_init=False)
+    api.token_source = "oauth"
+
+    class _Ctx:
+        class request_context:  # noqa: N801 - mirrors the MCP Context shape
+            lifespan_context = {"api": api}
+
+    fake_norman.deny = {"CO-FOREIGN"}
+    try:
+        result = _serve_request(
+            api,
+            provider,
+            "mcp_a",
+            "norman_a",
+            lambda: asyncio.run(switch_company(_Ctx(), company_id="CO-FOREIGN")),
+        )
+    finally:
+        tax_advisor_module.config = original
+        fake_norman.deny = set()
+
+    assert "error" in result, f"switch reported success for an inaccessible company: {result}"
+    assert result.get("activeCompanyId") is None
+    assert provider.token_to_company_id == {}, "persisted a company the caller cannot reach"
+
+
+def test_selection_is_reused_without_refetching(provider, fake_norman):
+    """A saved selection short-circuits the /companies/ lookup."""
+    api = NormanAPI(authenticate_on_init=False)
+    api.token_source = "oauth"
+
+    _serve_request(api, provider, "mcp_a", "norman_a", lambda: api.set_company("CO-CHOSEN"))
+
+    def count_lookups():
+        return sum(1 for path, _ in fake_norman.seen if path == "/api/v1/companies/")
+
+    before = count_lookups()
+    _serve_request(api, provider, "mcp_a", "norman_a", lambda: api.company_id)
+
+    assert count_lookups() == before, "re-resolved the company despite a saved selection"


### PR DESCRIPTION
`switch_company` documents that *"all subsequent tool calls will operate on the
selected company"*, but it kept that promise by writing `company_id` onto the
shared `NormanAPI` instance — the same shared mutable state that leaked companies
between users. Once identity became request-scoped, the selection stopped
surviving the request that made it. Under the stateless transport it had
**already** stopped before that: the lifespan builds a fresh client per request
and re-resolved the caller's first company every time.

The selection now lives in `NormanOAuthProvider.token_to_company_id`, keyed by
the caller's own MCP token and persisted in the state file. Keying by the token is
what makes it safe — a selection is reachable only by the request presenting that
token, so it can never become a shared default the way the old attribute did.
Entries are dropped when the token expires or is revoked.

### Changes

- **provider.py** — `token_to_company_id` + persistence; `load_access_token`
  seeds the caller's saved selection into the request context;
  `get_company_for_token` / `set_company_for_token`.
- **client.py** — the `company_id` property falls back to the saved selection
  before looking up a default, and the setter persists it. The lazy default
  lookup deliberately does **not** persist, so a default is never mistaken for a
  choice.
- **client.py** — `set_token` no longer resolves the company eagerly: it would
  overwrite the seeded selection, and it cost an API round trip on every request
  including ones that never need a company.
- **tax_advisor.py** — `switch_company` confirms the company is reachable
  **before** recording it. `/companies/{id}/` is scoped by `request.user`
  server-side (`Company.objects.for_user`), so an inaccessible company answers
  with an error. This matters beyond correctness: the active company id is sent as
  the `company` field when creating a transaction, so a caller must not be able to
  pin an arbitrary one onto their own session.

### Tests

`tests/test_company_selection.py` — 6 tests: persistence across requests,
invisibility to another user, concurrent switches not crossing, a default not
being persisted as a choice, no refetch when a selection exists, and an
unreachable company not being recorded.

Four of them fail on `f45876f` (`switch_company did not outlive the request`).
The unreachable-company test fails if the validation is moved back after the
write — verified by temporarily reordering it.

Full suite: 35 passed (`tests/test_basic.py` excluded, broken on `main`
independently).

### Known limitation

The selection is keyed by access token, so a refresh (≥24h) falls back to the
default company. Carrying it across token rotations needs a session identity the
provider does not have; deliberately not invented here.

### Relation to #68

Ports the mechanism from #68, which could not be rebased — `main` has moved 35
commits since it was opened, across every file it touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
