### PR TITLE
Add opt-in Sentry error reporting, with credential scrubbing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY . /app/
 
 # Install the package and additional dependencies
 RUN pip install -e . && \
-    pip install fastapi uvicorn pydantic pdf2image pillow requests
+    pip install fastapi uvicorn pydantic pdf2image pillow requests sentry-sdk
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1

--- a/norman_mcp/cli.py
+++ b/norman_mcp/cli.py
@@ -33,7 +33,12 @@ def main():
     """Main entry point for the CLI."""
     # Load environment variables
     load_dotenv()
-    
+
+    # Before anything else, so that failures during argument parsing and server
+    # construction are reported too. No-op unless SENTRY_DSN is set.
+    from .observability import init_sentry
+    init_sentry()
+
     parser = argparse.ArgumentParser(description='Norman Finance MCP Server with OAuth')
     parser.add_argument('--email', help='Norman Finance account email (optional)')
     parser.add_argument('--password', help='Norman Finance account password (optional)')

--- a/norman_mcp/observability.py
+++ b/norman_mcp/observability.py
@@ -1,0 +1,221 @@
+"""Optional Sentry wiring for the Norman MCP server.
+
+The server brokers OAuth credentials for third-party providers (Gmail,
+Microsoft 365, PayPal, Stripe, Qonto) and mints its own MCP tokens, so error
+reporting is deliberately conservative:
+
+* Opt-in. Without ``SENTRY_DSN`` nothing is imported and nothing is sent, which
+  keeps the local/stdio use of this package (and the published PyPI wheel)
+  unchanged.
+* Everything that leaves the process passes through :func:`scrub_event` first.
+  ``send_default_pii=False`` only stops the SDK from *adding* identifying data;
+  it does not redact secrets the application itself put into a URL, a header or
+  an exception message. The scrubber below is what actually does that.
+
+Tracing defaults to off: this service is diagnosed from errors, and performance
+transactions would be the expensive half of the quota.
+"""
+
+import logging
+import os
+import re
+from typing import Any, Dict, Optional
+from urllib.parse import urlsplit, urlunsplit
+
+logger = logging.getLogger(__name__)
+
+FILTERED = "[Filtered]"
+
+# Matched case-insensitively against mapping keys (headers, cookies, query
+# params, form fields, breadcrumb data). Substring match, so "client_secret"
+# also covers "NORMAN_OAUTH_CLIENT_SECRET" and "x-client-secret".
+_SENSITIVE_KEY_PARTS = (
+    "authorization",
+    "cookie",
+    "password",
+    "secret",
+    "token",
+    "api-key",
+    "api_key",
+    "apikey",
+    "session-id",
+    "session_id",
+    # OAuth authorization-code flow: both halves are single-use credentials.
+    "code",
+    "state",
+)
+
+# "Bearer eyJ…" / "Basic dXNlcjpwYXNz" anywhere in free text.
+_AUTH_SCHEME_RE = re.compile(
+    r"\b(bearer|basic|token)\s+[A-Za-z0-9\-._~+/=]{8,}",
+    re.IGNORECASE,
+)
+
+# "code=abc123", "access_token=…", "client_secret=…" inside a URL or message.
+_QUERY_SECRET_RE = re.compile(
+    r"\b("
+    r"code|state|token|access_token|refresh_token|id_token"
+    r"|client_secret|api_key|apikey|password"
+    r")=[^&\s\"'}\]]+",
+    re.IGNORECASE,
+)
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    if not isinstance(key, str):
+        return False
+    lowered = key.lower()
+    return any(part in lowered for part in _SENSITIVE_KEY_PARTS)
+
+
+def scrub_text(value: Any) -> Any:
+    """Redact credentials embedded in free text (messages, URLs, values)."""
+    if not isinstance(value, str):
+        return value
+    scrubbed = _AUTH_SCHEME_RE.sub(lambda m: f"{m.group(1)} {FILTERED}", value)
+    scrubbed = _QUERY_SECRET_RE.sub(lambda m: f"{m.group(1)}={FILTERED}", scrubbed)
+    return scrubbed
+
+
+def scrub_structure(value: Any, _depth: int = 0) -> Any:
+    """Recursively redact sensitive keys and credential-looking strings.
+
+    Depth is bounded so a self-referential or pathological payload cannot turn
+    error reporting into the outage it was meant to report.
+    """
+    if _depth > 8:
+        return FILTERED
+    if isinstance(value, dict):
+        return {
+            key: FILTERED if _is_sensitive_key(key) else scrub_structure(item, _depth + 1)
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        scrubbed = [scrub_structure(item, _depth + 1) for item in value]
+        return type(value)(scrubbed) if isinstance(value, tuple) else scrubbed
+    return scrub_text(value)
+
+
+def strip_query(url: Any) -> Any:
+    """Drop the query and fragment from a URL, keeping it useful for grouping."""
+    if not isinstance(url, str) or not url:
+        return url
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return FILTERED
+    if not parts.query and not parts.fragment:
+        return url
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+
+
+def _scrub_request(request: Dict[str, Any]) -> None:
+    # Bodies on this service are token exchanges and tool arguments; neither is
+    # worth the risk, so the whole thing goes rather than being walked.
+    if "data" in request:
+        request["data"] = FILTERED
+    if request.get("query_string"):
+        request["query_string"] = FILTERED
+    if "cookies" in request:
+        request["cookies"] = FILTERED
+    if "url" in request:
+        request["url"] = strip_query(request["url"])
+    headers = request.get("headers")
+    if isinstance(headers, dict):
+        request["headers"] = scrub_structure(headers)
+
+
+def scrub_event(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Redact credentials across every part of a Sentry event.
+
+    Pure and importable without ``sentry_sdk`` so it can be unit-tested on its
+    own; :func:`init_sentry` installs it as ``before_send``.
+    """
+    if not isinstance(event, dict):
+        return event
+
+    request = event.get("request")
+    if isinstance(request, dict):
+        _scrub_request(request)
+
+    exception = event.get("exception")
+    if isinstance(exception, dict):
+        for entry in exception.get("values") or []:
+            if isinstance(entry, dict) and "value" in entry:
+                entry["value"] = scrub_text(entry["value"])
+
+    logentry = event.get("logentry")
+    if isinstance(logentry, dict):
+        if "message" in logentry:
+            logentry["message"] = scrub_text(logentry["message"])
+        if "params" in logentry:
+            logentry["params"] = scrub_structure(logentry["params"])
+
+    if "message" in event:
+        event["message"] = scrub_text(event["message"])
+
+    for key in ("extra", "contexts", "tags"):
+        if key in event:
+            event[key] = scrub_structure(event[key])
+
+    breadcrumbs = event.get("breadcrumbs")
+    if isinstance(breadcrumbs, dict):
+        breadcrumbs["values"] = scrub_structure(breadcrumbs.get("values") or [])
+    elif isinstance(breadcrumbs, list):
+        event["breadcrumbs"] = scrub_structure(breadcrumbs)
+
+    return event
+
+
+def _before_send(event: Dict[str, Any], hint: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    try:
+        return scrub_event(event)
+    except Exception:  # pragma: no cover - defensive
+        # A scrubber that raises would drop the event silently on some SDK
+        # versions and send it unscrubbed on others. Neither is acceptable, so
+        # fail closed: report that something happened, without the payload.
+        logger.exception("Sentry before_send scrubbing failed; dropping event payload")
+        return {"message": "Event dropped: scrubbing failed", "level": "error"}
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Ignoring non-numeric %s=%r, using %s", name, raw, default)
+        return default
+
+
+def init_sentry() -> bool:
+    """Initialise Sentry when a DSN is configured. Returns True if enabled."""
+    dsn = os.environ.get("SENTRY_DSN", "").strip()
+    if not dsn:
+        return False
+
+    try:
+        import sentry_sdk
+    except ImportError:
+        logger.warning(
+            "SENTRY_DSN is set but sentry-sdk is not installed; "
+            "install it with: pip install 'norman-mcp-server[sentry]'"
+        )
+        return False
+
+    sentry_sdk.init(
+        dsn=dsn,
+        environment=os.environ.get("SENTRY_ENVIRONMENT")
+        or os.environ.get("NORMAN_ENVIRONMENT", "production"),
+        release=os.environ.get("SENTRY_RELEASE") or None,
+        # Errors are the signal here; transactions are the expensive half.
+        traces_sample_rate=_env_float("SENTRY_TRACES_SAMPLE_RATE", 0.0),
+        profiles_sample_rate=_env_float("SENTRY_PROFILES_SAMPLE_RATE", 0.0),
+        send_default_pii=False,
+        include_local_variables=False,
+        max_request_body_size="never",
+        before_send=_before_send,
+    )
+    logger.info("Sentry error reporting enabled")
+    return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,11 @@ sse = [
     "uvicorn>=0.22.0",
     "pydantic>=2.0.0",
 ]
+# Error reporting for the hosted deployment. Kept optional so the published
+# wheel and local stdio use stay dependency-free; see norman_mcp/observability.py.
+sentry = [
+    "sentry-sdk>=2.0.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/norman-finance/norman-mcp-server"

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,223 @@
+"""Tests for the Sentry event scrubber.
+
+These run without sentry-sdk installed: the scrubbing helpers are deliberately
+pure so the security-relevant half of the integration is testable on its own.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from norman_mcp.observability import (
+    FILTERED,
+    init_sentry,
+    scrub_event,
+    scrub_structure,
+    scrub_text,
+    strip_query,
+)
+
+
+class TestScrubText:
+    def test_redacts_bearer_token(self):
+        out = scrub_text("Failed with Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
+        assert "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" not in out
+        assert FILTERED in out
+
+    def test_redacts_basic_auth(self):
+        out = scrub_text("Authorization: Basic dXNlcjpwYXNzd29yZA==")
+        assert "dXNlcjpwYXNzd29yZA==" not in out
+
+    def test_redacts_oauth_code_in_url(self):
+        out = scrub_text("callback failed: https://mcp.norman.finance/cb?code=4/0Ab_c-XYZ&state=zz")
+        assert "4/0Ab_c-XYZ" not in out
+        assert "state=zz" not in out
+        # The useful part of the message survives.
+        assert "mcp.norman.finance" in out
+
+    def test_redacts_client_secret_and_tokens(self):
+        out = scrub_text("client_secret=abc123&refresh_token=r3fr3sh&access_token=acc3ss")
+        for secret in ("abc123", "r3fr3sh", "acc3ss"):
+            assert secret not in out
+
+    def test_leaves_ordinary_text_alone(self):
+        msg = "Connection closed while listing invoices for company 42"
+        assert scrub_text(msg) == msg
+
+    def test_non_string_passes_through(self):
+        assert scrub_text(7) == 7
+        assert scrub_text(None) is None
+
+
+class TestStripQuery:
+    def test_removes_query_and_fragment(self):
+        assert strip_query("https://x.test/cb?code=secret#tok") == "https://x.test/cb"
+
+    def test_keeps_plain_url(self):
+        assert strip_query("https://x.test/mcp") == "https://x.test/mcp"
+
+    def test_handles_empty_and_non_string(self):
+        assert strip_query("") == ""
+        assert strip_query(None) is None
+
+
+class TestScrubStructure:
+    def test_redacts_sensitive_keys_case_insensitively(self):
+        out = scrub_structure(
+            {
+                "Authorization": "Bearer abc",
+                "NORMAN_OAUTH_CLIENT_SECRET": "shhh",
+                "Mcp-Session-Id": "sess-1",
+                "code": "4/0Ab",
+                "state": "xyz",
+                "content-type": "application/json",
+            }
+        )
+        assert out["Authorization"] == FILTERED
+        assert out["NORMAN_OAUTH_CLIENT_SECRET"] == FILTERED
+        assert out["Mcp-Session-Id"] == FILTERED
+        assert out["code"] == FILTERED
+        assert out["state"] == FILTERED
+        # Non-sensitive metadata is preserved — the event stays useful.
+        assert out["content-type"] == "application/json"
+
+    def test_recurses_into_nested_containers(self):
+        out = scrub_structure({"a": [{"password": "p"}, {"ok": "Bearer tokenvalue123"}]})
+        assert out["a"][0]["password"] == FILTERED
+        assert "tokenvalue123" not in out["a"][1]["ok"]
+
+    def test_bounded_depth_does_not_recurse_forever(self):
+        payload = current = {}
+        for _ in range(50):
+            current["next"] = {}
+            current = current["next"]
+        # Must terminate rather than blow the stack.
+        assert scrub_structure(payload) is not None
+
+    def test_preserves_tuple_type(self):
+        assert isinstance(scrub_structure(("a", "b")), tuple)
+
+
+class TestScrubEvent:
+    def test_scrubs_request_block(self):
+        event = {
+            "request": {
+                "url": "https://mcp.norman.finance/oauth/callback?code=4/0Ab&state=xy",
+                "query_string": "code=4/0Ab&state=xy",
+                "data": {"client_secret": "shhh"},
+                "cookies": {"session": "abc"},
+                "headers": {"Authorization": "Bearer abc", "Accept": "application/json"},
+            }
+        }
+        out = scrub_event(event)
+        req = out["request"]
+        assert req["url"] == "https://mcp.norman.finance/oauth/callback"
+        assert req["query_string"] == FILTERED
+        assert req["data"] == FILTERED
+        assert req["cookies"] == FILTERED
+        assert req["headers"]["Authorization"] == FILTERED
+        assert req["headers"]["Accept"] == "application/json"
+
+    def test_scrubs_exception_value(self):
+        event = {
+            "exception": {
+                "values": [
+                    {"type": "HTTPError", "value": "401 for Bearer eyJsecrettokenvalue"}
+                ]
+            }
+        }
+        out = scrub_event(event)
+        assert "eyJsecrettokenvalue" not in out["exception"]["values"][0]["value"]
+
+    def test_scrubs_logentry_extra_and_breadcrumbs(self):
+        event = {
+            "logentry": {"message": "token=abcdef123", "params": {"password": "p"}},
+            "extra": {"access_token": "tok", "company": "acme"},
+            "breadcrumbs": {"values": [{"message": "client_secret=zzz"}]},
+        }
+        out = scrub_event(event)
+        assert "abcdef123" not in out["logentry"]["message"]
+        assert out["logentry"]["params"]["password"] == FILTERED
+        assert out["extra"]["access_token"] == FILTERED
+        assert out["extra"]["company"] == "acme"
+        assert "zzz" not in out["breadcrumbs"]["values"][0]["message"]
+
+    def test_handles_breadcrumbs_as_list(self):
+        event = {"breadcrumbs": [{"message": "Bearer abcdefgh12345"}]}
+        out = scrub_event(event)
+        assert "abcdefgh12345" not in out["breadcrumbs"][0]["message"]
+
+    def test_tolerates_missing_and_odd_shapes(self):
+        assert scrub_event({}) == {}
+        assert scrub_event({"exception": {"values": []}}) is not None
+        assert scrub_event({"request": {}}) is not None
+
+
+class TestInitSentry:
+    def test_no_dsn_is_a_noop(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert init_sentry() is False
+
+    def test_blank_dsn_is_a_noop(self):
+        with patch.dict(os.environ, {"SENTRY_DSN": "   "}, clear=True):
+            assert init_sentry() is False
+
+    def test_missing_sdk_degrades_gracefully(self):
+        real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "sentry_sdk":
+                raise ImportError("no sentry_sdk")
+            return real_import(name, *args, **kwargs)
+
+        with patch.dict(os.environ, {"SENTRY_DSN": "https://k@o1.ingest.sentry.io/1"}, clear=True):
+            with patch("builtins.__import__", side_effect=fake_import):
+                # Must not raise: a missing optional dep cannot break startup.
+                assert init_sentry() is False
+
+    def test_initialises_with_safe_defaults(self):
+        sentry_sdk = pytest.importorskip("sentry_sdk")
+        env = {
+            "SENTRY_DSN": "https://k@o1.ingest.sentry.io/1",
+            "NORMAN_ENVIRONMENT": "production",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with patch.object(sentry_sdk, "init") as mock_init:
+                assert init_sentry() is True
+        kwargs = mock_init.call_args.kwargs
+        assert kwargs["environment"] == "production"
+        assert kwargs["send_default_pii"] is False
+        assert kwargs["include_local_variables"] is False
+        assert kwargs["max_request_body_size"] == "never"
+        # Tracing off unless explicitly turned on.
+        assert kwargs["traces_sample_rate"] == 0.0
+        assert kwargs["profiles_sample_rate"] == 0.0
+        assert kwargs["before_send"] is not None
+
+    def test_sample_rates_and_environment_from_env(self):
+        sentry_sdk = pytest.importorskip("sentry_sdk")
+        env = {
+            "SENTRY_DSN": "https://k@o1.ingest.sentry.io/1",
+            "SENTRY_ENVIRONMENT": "stage",
+            "NORMAN_ENVIRONMENT": "production",
+            "SENTRY_TRACES_SAMPLE_RATE": "0.25",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with patch.object(sentry_sdk, "init") as mock_init:
+                init_sentry()
+        kwargs = mock_init.call_args.kwargs
+        # SENTRY_ENVIRONMENT wins over NORMAN_ENVIRONMENT.
+        assert kwargs["environment"] == "stage"
+        assert kwargs["traces_sample_rate"] == 0.25
+
+    def test_non_numeric_sample_rate_falls_back(self):
+        sentry_sdk = pytest.importorskip("sentry_sdk")
+        env = {
+            "SENTRY_DSN": "https://k@o1.ingest.sentry.io/1",
+            "SENTRY_TRACES_SAMPLE_RATE": "high",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with patch.object(sentry_sdk, "init") as mock_init:
+                init_sentry()
+        assert mock_init.call_args.kwargs["traces_sample_rate"] == 0.0


### PR DESCRIPTION
## Problem

The hosted MCP server has **no error reporting at all**.

- The Sentry project `norman-mcp` exists but has received **zero events in 90 days** (`is:unresolved is:resolved is:ignored`, 90d → no results).
- `grep -rn "sentry" --include="*.py" --include="*.toml" .` on `main` returns nothing: no dependency, no init.
- `mcp.env.j2` in norman-devops has no `SENTRY_DSN`.

The empty project is worse than a known gap, because it reads as coverage.

The only signal today is the container healthcheck added in norman-devops#66. By design it accepts **any** HTTP status below 500, so it proves the ASGI app answers and nothing more.

This is the least observable service in the fleet and currently the fastest moving one — `master..develop` on the API is 24 commits, mostly connector work, and norman-devops #75, #76, #77, #78, #79 and #81 are all MCP. It also brokers OAuth credentials for Gmail, Microsoft 365, PayPal, Stripe and Qonto.

It has already failed silently in production. The placement comment in `production/mcp.yml` records 2026-07-27: a replica rescheduled onto another node, came up against an unrelated node-local `mcp-data` volume, signed connected users out and brought revoked tokens back. That produced no alert of any kind.

## What this does

Adds `norman_mcp/observability.py` and calls `init_sentry()` as the first thing in `cli.main()`, so failures during argument parsing and server construction are covered too.

**The scrubber is the point of the change, not a detail.** `send_default_pii=False` only stops the SDK from *adding* identifying data — it does nothing about secrets the application itself puts into a URL, a header or an exception message. Every event goes through `scrub_event` first:

| Surface | Treatment |
|---|---|
| Request body, cookies | dropped wholesale |
| URL, `query_string` | query and fragment stripped |
| Headers, `extra`, `contexts`, `tags`, `logentry.params`, breadcrumbs | walked; keys containing `authorization`/`cookie`/`password`/`secret`/`token`/`api-key`/`session-id`/`code`/`state` replaced with `[Filtered]` |
| Exception values, messages | regex-scrubbed for `Bearer …`-style credentials and `code=` / `access_token=` / `client_secret=` fragments |

Recursion is depth-bounded (a pathological payload can't turn error reporting into the outage it was meant to report), and a scrubber that somehow raises **fails closed** — it drops the payload rather than sending it unredacted.

Everything else is deliberately conservative:

- **Opt-in.** No `SENTRY_DSN` → nothing imported, nothing sent. The published wheel and local stdio use are unchanged.
- **`sentry-sdk` is an optional extra**, not a hard dependency. Only the Docker image installs it.
- **Tracing and profiling default to `0.0`.** Errors are the signal for this service; transactions would be the expensive half of the quota. Both are overridable by env.
- A missing `sentry-sdk` logs a warning instead of breaking startup.
- `environment` comes from the existing `NORMAN_ENVIRONMENT` (already `production` in `mcp.env.j2`), overridable via `SENTRY_ENVIRONMENT` — no second source of truth.

## Tests

The scrubbing helpers are pure and importable without `sentry-sdk`, so the security-relevant half is testable on its own. **24 new tests** in `tests/test_observability.py` cover bearer/basic token redaction, OAuth `code`/`state` in URLs, case-insensitive key matching, nested containers, depth bounding, all the event shapes above, graceful degradation when the SDK is absent, and the init defaults.

```
tests/test_observability.py .......................  24 passed
```

Suite state is unchanged otherwise — verified A/B against a clean `origin/main` worktree:

| | clean `origin/main` | this branch |
|---|---|---|
| collection errors | `test_basic.py`, `test_validate_input.py` | identical |
| failures | `test_redirect_allowlist`, `test_company_selection` | identical |
| passed | 17 | **41** |

All four pre-existing problems reproduce unchanged on `main`; this branch adds 24 passing tests and breaks nothing. (Repo CI builds the image and does not run pytest.)

## Deploying

This commit changes nothing at runtime on its own. It needs `SENTRY_DSN` set in norman-devops `mcp.env.j2` — that half is norman-devops#82.

Order matters: **merge and deploy this first, then set the DSN.** Pointing the DSN at a build without the scrubber would ship OAuth codes and bearer tokens to Sentry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)