### PR TITLE
packaging: include subpackages in the distribution (published wheel is missing most of the package)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,11 @@ Issues = "https://github.com/norman-finance/norman-mcp-server/issues"
 [project.scripts]
 norman-mcp = "norman_mcp.cli:main"
 
-[tool.setuptools]
-packages = ["norman_mcp"]
+[tool.setuptools.packages.find]
+include = ["norman_mcp*"]
+
+[tool.setuptools.package-data]
+norman_mcp = ["static/*", "files/*"]
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
## The bug

`pyproject.toml` declares:

```toml
[tool.setuptools]
packages = ["norman_mcp"]
```

That's an explicit, **non-recursive** list, so the built distribution contains only the top-level modules. Every subpackage — `api`, `tools`, `auth`, `config`, `prompts`, `resources`, `security`, `files` — is silently dropped.

The **published 0.1.7 wheel on PyPI** has this problem today:

```
norman_mcp/__init__.py  __main__.py  cli.py  context.py  server.py
# subpackage files: 0
```

So `pip install norman-mcp-server` produces an install that fails on startup:

```
ModuleNotFoundError: No module named 'norman_mcp.api'
```

It's easy to miss because `norman-mcp --help` still works — argparse exits before `server.py` is imported, so the install looks healthy until you actually run it.

## Reproduction (clean clone of current `main`)

```bash
git clone https://github.com/norman-finance/norman-mcp-server && cd norman-mcp-server
python -m build --wheel
unzip -l dist/*.whl | grep -cE 'norman_mcp/[a-z_]+/'   # => 0
```

⚠️ Note: building in a tree that already has a `*.egg-info/` (e.g. after `pip install -e .`) *masks* the bug — the stale `SOURCES.txt` pulls the subpackages back in. A pristine clone shows it.

## The fix + verification

| | top-level modules | subpackage files |
|---|---|---|
| before | 6 | **0** |
| after | 6 | **33** (api, auth, config, files, prompts, resources, security, static, tools) |

Installed the resulting wheel into a fresh venv and confirmed it works:

```python
import norman_mcp.api.client, norman_mcp.tools.vendors, norman_mcp.server  # OK
```

Also declares `package-data` so `static/` (favicon) and `files/` ship with the wheel.

Worth a 0.1.8 release once merged, since the current PyPI artifact is unusable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)