### PR TITLE
feat(categories): hide/unhide company categories in bulk

### DIFF
--- a/norman_mcp/prompts/templates.py
+++ b/norman_mcp/prompts/templates.py
@@ -250,6 +250,8 @@ def register_prompts(mcp):
             "and switched in settings.\n\n"
             "### Available Tools for SME\n"
             "- `list_company_categories` — browse DATEV categories\n"
+            "- `set_company_categories_visibility` — hide/unhide categories in bulk (e.g. a company "
+            "carrying both SKR03 and SKR04 accounts: hide the chart it does not use)\n"
             "- `list_coa_templates` — see available CoA templates\n"
             "- `trigger_datev_export` — generate DATEV export for tax advisor\n"
             "- `create_transaction` / `update_transaction` — with company_category_id, payment_date, payment_type\n"

--- a/norman_mcp/tools/categories.py
+++ b/norman_mcp/tools/categories.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 from urllib.parse import urljoin
 
 from mcp.types import ToolAnnotations
@@ -176,3 +176,92 @@ def register_category_tools(mcp):
             body["description"] = description
 
         return api._make_request("POST", categories_url, json_data=body)
+
+    @mcp.tool(
+        title="Hide or Unhide Company Categories (SME only)",
+        annotations=ToolAnnotations(
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    )
+    async def set_company_categories_visibility(
+        ctx: Context,
+        action: str = Field(description="'hide' to take the categories out of use, 'unhide' to bring them back"),
+        chart_template: Optional[str] = Field(
+            default=None,
+            description=(
+                "Select every row provisioned from this chart of accounts: 'skr03', 'skr04', "
+                "'PL_FULL', 'PL_KPIR'. This is how you clean up a company that ended up with "
+                "two charts at once — e.g. hide chart_template='skr04' to leave only SKR03."
+            ),
+        ),
+        codes: Optional[List[str]] = Field(default=None, description="Select by account code, e.g. ['4200', '6815']"),
+        category_ids: Optional[List[str]] = Field(
+            default=None,
+            description="Select explicit category ids as returned by list_company_categories",
+        ),
+        cashflow_type: Optional[str] = Field(default=None, description="Restrict to INCOME, EXPENSE or EQUITY rows"),
+        include_custom: bool = Field(
+            default=False,
+            description=(
+                "Also affect categories the company created itself. Off by default so a "
+                "chart-wide sweep never touches hand-made accounts; ids always apply."
+            ),
+        ),
+        dry_run: bool = Field(
+            default=False,
+            description="Return the selection without changing anything. Use before a chart-wide sweep.",
+        ),
+    ) -> Dict[str, Any]:
+        """
+        Hide or unhide SME company categories in bulk.
+
+        ⚠️ SME ONLY — GmbH/UG companies with a DATEV chart of accounts.
+
+        Hidden categories disappear from the category pickers in the app and from
+        the candidate list the AI categorizer picks from. Nothing is deleted:
+        transactions already booked on a hidden category keep it (the result
+        reports transactionsCount / itemsCount per row), and unhiding restores
+        the row exactly as it was.
+
+        The main use: a company whose chart was provisioned twice and now shows
+        both SKR03 and SKR04 accounts. Hide the chart it does not use.
+
+        Selectors combine with AND and at least one is required. A non-zero
+        summary.skippedCustom means the filter passed over hand-made accounts —
+        rerun with include_custom=true if the user meant those too. Preview with
+        dry_run=true and tell the user what would be hidden before doing it for
+        real — this changes what they can book on.
+        """
+        api = ctx.request_context.lifespan_context["api"]
+        if not api.company_id:
+            return {"error": "No company available. Please authenticate first."}
+
+        if not await _check_sme(api):
+            return _SME_ONLY_ERROR
+
+        normalized = (action or "").strip().lower()
+        if normalized not in ("hide", "unhide"):
+            return {"error": f"Unknown action '{action}'. Use 'hide' or 'unhide'."}
+
+        body: Dict[str, Any] = {
+            "isActive": normalized == "unhide",
+            "includeCustom": include_custom,
+            "dryRun": dry_run,
+        }
+        if chart_template:
+            body["chartTemplate"] = chart_template
+        if codes:
+            body["codes"] = codes
+        if category_ids:
+            body["categoryIds"] = category_ids
+        if cashflow_type:
+            body["cashflowType"] = cashflow_type
+
+        visibility_url = urljoin(
+            config.api_base_url,
+            "api/v1/accounting/company-categories/set-visibility/",
+        )
+        return api._make_request("POST", visibility_url, json_data=body)

--- a/norman_mcp/tools/company.py
+++ b/norman_mcp/tools/company.py
@@ -147,11 +147,24 @@ def register_company_tools(mcp):
     async def list_company_categories(
         ctx: Context,
         cashflow_type: Optional[str] = Field(default=None, description="Filter by cashflow type: INCOME or EXPENSE"),
+        chart_template: Optional[str] = Field(
+            default=None,
+            description="Keep only rows provisioned from this chart of accounts: 'skr03', 'skr04', 'PL_FULL'",
+        ),
+        include_inactive: bool = Field(
+            default=False,
+            description="Also return hidden categories (isActive=false). Needed before unhiding anything.",
+        ),
     ) -> Dict[str, Any]:
         """
         List SME company categories from the DATEV chart of accounts (SKR03/SKR04).
         These categories are specific to the company and are used for GmbH/UG bookkeeping.
-        Each category has a code (e.g. '4200'), name, and cashflow type.
+        Each category has a code (e.g. '4200'), name, cashflow type, and sourceTemplate —
+        the chart of accounts it was provisioned from ('' for hand-made ones). A company
+        showing both SKR03 and SKR04 accounts can be cleaned up with
+        set_company_categories_visibility.
+
+        Hidden categories are omitted unless include_inactive=true.
         """
         api = ctx.request_context.lifespan_context["api"]
         company_id = api.company_id
@@ -167,6 +180,10 @@ def register_company_tools(mcp):
         params = {"pageSize": 200}
         if cashflow_type:
             params["cashflowType"] = cashflow_type
+        if chart_template:
+            params["chartTemplate"] = chart_template
+        if include_inactive:
+            params["includeInactive"] = "true"
         
         return api._make_request("GET", categories_url, params=params)
 


### PR DESCRIPTION
## Why

Norman's API has had a per-row hide/unhide on SME company categories for a while (`PATCH {isActive}` + `?includeInactive=true`), but this server exposed no tool for it, so a user could not ask the assistant to clean up their chart of accounts.

Selecting a whole chart was impossible anyway: `list_company_categories` never returned which chart of accounts a row was provisioned from, and account codes cannot tell SKR03 from SKR04 apart — both number 0000–9999 with heavy overlap. A company whose chart got provisioned twice ends up showing accounts from both, and hiding them one at a time is not a fix anyone performs.

## What

- **`set_company_categories_visibility`** — hide or unhide in bulk by chart of accounts (`chart_template='skr04'`), by account code, by cashflow direction, or by explicit ids. Selectors are AND-ed and at least one is required, so a vague request can never sweep the whole chart. `dry_run=true` previews; hand-made accounts are skipped unless `include_custom=true` (the response counts them in `summary.skippedCustom`); the API refuses a hide that would leave no bookable category behind; and each returned row reports `transactionsCount` / `itemsCount`, because hiding deletes nothing and re-categorizes nothing — bookings stay on the row they are on.
- **`list_company_categories`** gains `include_inactive` (needed before unhiding anything) and `chart_template`, and now surfaces the `sourceTemplate` each row came from (`''` for hand-made rows).
- The SME bookkeeping prompt advertises the tool along with the case it exists for.

Both are SME-only, like the rest of `tools/categories.py`, and go through the same `_check_sme` gate.

## Dependency

Backed by `POST /api/v1/accounting/company-categories/set-visibility/` in norman-finance/norman-finance-api#2529 — that one must be deployed first, otherwise the tool gets a 404.

## Testing

`create_app()` boots and lists the tool with a valid schema — only `action` is required, `codes` / `category_ids` typed as string arrays. The API side carries 15 new tests for the endpoint's behaviour (selection, dry run, guards, cross-company isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)