### PR TITLE
chore: refresh MCP registry listing metadata (v0.1.8)

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,9 +1,16 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "finance.norman/mcp-server",
-  "title": "Norman MCP Server",
-  "description": "AI-powered bookkeeping and tax filing for entrepreneurs at the heart of the European economy.",
-  "version": "0.1.7",
+  "title": "Norman Finance — Accounting, Bookkeeping & Taxes (Germany)",
+  "description": "AI accounting for German businesses: bookkeeping, invoices, receipts, VAT & tax filing via ELSTER.",
+  "icons": [
+    {
+      "src": "https://norman.finance/icon.png",
+      "mimeType": "image/png"
+    }
+  ],
+  "version": "0.1.8",
+  "websiteUrl": "https://norman.finance",
   "repository": {
     "url": "https://github.com/norman-finance/norman-mcp-server",
     "source": "github"
@@ -18,7 +25,7 @@
     {
       "registryType": "pypi",
       "identifier": "norman-mcp-server",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## What

Refreshes `server.json` for the official MCP registry (registry.modelcontextprotocol.io):

- **title** → `Norman Finance — Accounting, Bookkeeping & Taxes (Germany)`
- **description** → keyword-rich one-liner (98/100 chars): accounting, bookkeeping, invoices, receipts, VAT, tax, ELSTER, German
- **icons** + **websiteUrl** — new schema fields we didn't set before (icon URL verified, returns 200)
- **version** → 0.1.8 (listing + pypi package ref)

## Why

Our registry listing has been stale at v0.1.7 since 2026-02-19. Registry search and downstream aggregators (PulseMCP, Glama, etc.) match lexically on listing metadata — the old description had no "accounting"/"tax" keywords, so the server was invisible for the queries that matter. Same fix as the Claude Directory listing update.

## Publish order (after merge)

1. Release `norman-mcp-server==0.1.8` to PyPI first (version bump in `pyproject.toml` is pending on a WIP branch; PyPI summary there could use the same keyword treatment).
2. Then `mcp-publisher login http --domain norman.finance && mcp-publisher publish` from the repo root. The `mcp-name` marker in README:293 is in place, so ownership validation passes.

Note: `websiteUrl` points at the domain root for now — `norman.finance/mcp` (EN) currently 404s (only `/de/mcp` is live); switch once the EN page is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)