### PR TITLE
fix: refresh the Norman token when the company lookup gets 401

### DIFF
--- a/norman_mcp/api/client.py
+++ b/norman_mcp/api/client.py
@@ -263,11 +263,19 @@ class NormanAPI:
         """Resolve and store the company id for the env/stdio token."""
         self.company_id = self._fetch_company_id(self.access_token)
 
-    def _fetch_company_id(self, token: Optional[str]) -> Optional[str]:
+    def _fetch_company_id(self, token: Optional[str], _refreshed: bool = False) -> Optional[str]:
         """Look up the first company for `token`'s owner.
 
         Pure in the token: it stores nothing on `self`, so it is safe to call
         concurrently for different users.
+
+        Handles its own 401. Norman access tokens live one hour, and this lookup
+        runs *before* any `_make_request` (tools need the company id to build
+        their URL), so it cannot inherit that method's transparent refresh.
+        Without the refresh below, an expired token surfaced to the user as the
+        misleading "No company available. Please authenticate first." roughly an
+        hour after connecting -- which is why permanent authentication appeared
+        impossible.
         """
         if not token:
             return None
@@ -290,7 +298,17 @@ class NormanAPI:
                 headers=headers,
                 timeout=config.NORMAN_API_TIMEOUT
             )
-            
+
+            if response.status_code == 401 and not _refreshed:
+                refreshed_token = self._reauthenticate_for_company_lookup()
+                if refreshed_token:
+                    return self._fetch_company_id(refreshed_token, _refreshed=True)
+                logger.warning(
+                    "Company lookup got 401 and the Norman token could not be "
+                    "refreshed; the client needs to reconnect"
+                )
+                return None
+
             response.raise_for_status()
             response_data = response.json()
             
@@ -312,6 +330,24 @@ class NormanAPI:
             logger.error(f"Error getting company ID: {str(e)}")
             # Don't set a fallback company ID - let API response indicate the error
             return None
+
+    def _reauthenticate_for_company_lookup(self) -> Optional[str]:
+        """Get a fresh Norman token after the company lookup returned 401.
+
+        OAuth mode refreshes via the provider (the refresh token is indexed by
+        the caller's MCP token, so this stays request-scoped). Single-tenant
+        env/stdio mode re-authenticates with its configured credentials.
+        """
+        if self.token_source == "env":
+            try:
+                self.authenticate()
+                return self.access_token
+            except Exception as e:
+                logger.error(f"Env re-authentication failed during company lookup: {e}")
+                return None
+
+        logger.info("Norman token expired during company lookup; refreshing")
+        return self._refresh_oauth_norman_token()
 
 
     def _make_request(self, method: str, url: str, params: Optional[Dict[str, Any]] = None, 

--- a/tests/test_company_lookup_refresh.py
+++ b/tests/test_company_lookup_refresh.py
@@ -1,0 +1,160 @@
+"""The company lookup must survive an expired Norman access token.
+
+Norman access tokens live one hour. Almost every tool reads `api.company_id`
+first, to build its company-scoped URL, so the lookup runs before any
+`_make_request` and cannot inherit that method's transparent refresh. Without
+its own 401 handling the lookup returned None and the user was told
+"No company available. Please authenticate first." about an hour after
+connecting -- reported as "permanent authentication must be possible".
+"""
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
+
+import pytest
+from mcp.server.auth.middleware.auth_context import auth_context_var
+from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
+from mcp.server.auth.provider import AccessToken
+
+from norman_mcp import context
+from norman_mcp.api import client as client_module
+from norman_mcp.api.client import NormanAPI
+
+EXPIRED = "norman_expired"
+FRESH = "norman_fresh"
+
+
+@pytest.fixture(autouse=True)
+def disable_actual_api_calls():
+    """Override the global autouse fixture: these tests need real HTTP."""
+    yield
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler API
+        token = self.headers.get("Authorization", "").removeprefix("Bearer ").strip()
+        path = urlparse(self.path).path
+        self.server.seen.append((path, token))
+
+        if token == EXPIRED:
+            self.send_response(401)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+
+        body = {"results": [{"publicId": f"company-of-{token}"}]}
+        payload = json.dumps(body).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *args):
+        pass
+
+
+class _Provider:
+    """Mimics the provider: the stored Norman token is stale until refreshed."""
+
+    def __init__(self, refreshable=True):
+        self.token_mapping = {"mcp_a": EXPIRED}
+        self.refreshable = refreshable
+        self.refresh_calls = 0
+
+    def get_norman_token(self, mcp_token):
+        return self.token_mapping.get(mcp_token)
+
+    def refresh_norman_token_sync(self, mcp_token):
+        self.refresh_calls += 1
+        if not self.refreshable:
+            return None
+        self.token_mapping[mcp_token] = FRESH
+        return FRESH
+
+    def get_company_for_token(self, mcp_token):
+        return None
+
+    def set_company_for_token(self, mcp_token, company_id):
+        pass
+
+
+@pytest.fixture
+def server():
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    srv.seen = []
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        yield srv
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def _wire(monkeypatch, server, provider):
+    host, port = server.server_address[:2]
+
+    class _Cfg:
+        api_base_url = f"http://{host}:{port}/"
+        NORMAN_API_TIMEOUT = 10
+
+    monkeypatch.setattr(client_module, "config", _Cfg())
+    monkeypatch.setattr(context, "oauth_provider", provider)
+
+
+def _in_request(fn):
+    out, errors = {}, []
+
+    def run():
+        try:
+            auth_context_var.set(
+                AuthenticatedUser(AccessToken(token="mcp_a", client_id="c", scopes=["read"]))
+            )
+            out["value"] = fn()
+        except BaseException as exc:
+            errors.append(exc)
+
+    t = threading.Thread(target=run)
+    t.start()
+    t.join(timeout=30)
+    if errors:
+        raise errors[0]
+    return out.get("value")
+
+
+def test_expired_token_is_refreshed_and_company_resolves(monkeypatch, server):
+    provider = _Provider()
+    _wire(monkeypatch, server, provider)
+
+    api = NormanAPI(authenticate_on_init=False)
+    api.token_source = "oauth"
+
+    assert _in_request(lambda: api.company_id) == f"company-of-{FRESH}"
+    assert provider.refresh_calls == 1
+    assert [t for _, t in server.seen] == [EXPIRED, FRESH]
+
+
+def test_refresh_is_attempted_only_once(monkeypatch, server):
+    """A token that stays rejected must not loop."""
+    provider = _Provider()
+    provider.refresh_norman_token_sync = lambda mcp_token: EXPIRED  # never fixes it
+    _wire(monkeypatch, server, provider)
+
+    api = NormanAPI(authenticate_on_init=False)
+    api.token_source = "oauth"
+
+    assert _in_request(lambda: api.company_id) is None
+    assert [t for _, t in server.seen] == [EXPIRED, EXPIRED]
+
+
+def test_unrefreshable_session_reports_no_company(monkeypatch, server):
+    provider = _Provider(refreshable=False)
+    _wire(monkeypatch, server, provider)
+
+    api = NormanAPI(authenticate_on_init=False)
+    api.token_source = "oauth"
+
+    assert _in_request(lambda: api.company_id) is None
+    assert provider.refresh_calls == 1


### PR DESCRIPTION
Norman access tokens expire after one hour (`ACCESS_TOKEN_EXPIRE_SECONDS`).
`_make_request` already refreshes them transparently — but almost every tool reads
`api.company_id` first, to build its company-scoped URL, so the company lookup runs
**before** any `_make_request` and never inherited that refresh.
`_fetch_company_id` issued a direct request and swallowed every failure in a broad
`except`, returning `None`.

User-visible result: roughly an hour after connecting, every company-scoped tool
answered *"No company available. Please authenticate first."*, and reconnecting was
the only workaround. Reported by a customer on the ChatGPT connector as
*"permanent authentication must be possible"*.

The machinery to fix this was already in the codebase — it just was not reachable
from this path.

### Change

`_fetch_company_id` handles its own 401 and retries once with a fresh token, via
`_reauthenticate_for_company_lookup`:

- OAuth mode — refresh through the provider, indexed by the caller's own MCP token,
  so it stays request-scoped.
- Single-tenant env/stdio — re-authenticate with the configured credentials.

A token that stays rejected fails cleanly rather than looping.

### Not a regression from the isolation work

The same silent failure existed beforehand. What changed is that it is now the
*only* outcome: while company state was shared across callers, an expired token
could be masked by a company id resolved from another session, so the request
appeared to succeed — against the wrong company.

### Tests

`tests/test_company_lookup_refresh.py` — refresh path, single-retry bound, and the
unrefreshable session. All three fail on `e4a3512`.

Full suite: 59 passed, 3 skipped (`tests/test_basic.py` excluded — broken on `main`
independently, it imports a `Config` symbol that no longer exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
