### PR TITLE
feat: add company accounting workspace MCP parity

### DIFF
--- a/norman_mcp/api/client.py
+++ b/norman_mcp/api/client.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import requests
 from dataclasses import dataclass
@@ -18,6 +19,7 @@ from norman_mcp.context import (
 # Configure logging
 logger = logging.getLogger(__name__)
 
+
 @dataclass
 class NormanAPI:
     """API client for Norman Finance.
@@ -29,6 +31,7 @@ class NormanAPI:
     `company_id` property -- both request-scoped. `access_token` /
     `_env_company_id` below are only for single-tenant env/stdio mode.
     """
+
     access_token: Optional[str] = None
     refresh_token: Optional[str] = None
     token_source: str = "env"  # can be 'env', 'oauth', or 'direct_login'
@@ -158,28 +161,38 @@ class NormanAPI:
         # If we already have a token, use it
         if self.access_token:
             return
-            
+
         # Skip authentication if requested
         if not self.authenticate_on_init:
             logger.info("Skipping automatic authentication on initialization")
             return
-            
+
         # Check if credentials are available before attempting authentication
         if not config.NORMAN_EMAIL or not config.NORMAN_PASSWORD:
-            logger.warning("Norman Finance credentials not set. Please set NORMAN_EMAIL and NORMAN_PASSWORD environment variables.")
-            logger.warning("The server will start, but API calls will fail until valid credentials are provided.")
+            logger.warning(
+                "Norman Finance credentials not set. Please set NORMAN_EMAIL and NORMAN_PASSWORD environment variables."
+            )
+            logger.warning(
+                "The server will start, but API calls will fail until valid credentials are provided."
+            )
             return
-        
+
         try:
             self.authenticate()
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 400:
-                logger.warning("Failed to authenticate with Norman Finance API: Invalid credentials.")
-                logger.warning("Please check your NORMAN_EMAIL and NORMAN_PASSWORD environment variables.")
-                logger.warning("The server will start, but API calls will fail until valid credentials are provided.")
+                logger.warning(
+                    "Failed to authenticate with Norman Finance API: Invalid credentials."
+                )
+                logger.warning(
+                    "Please check your NORMAN_EMAIL and NORMAN_PASSWORD environment variables."
+                )
+                logger.warning(
+                    "The server will start, but API calls will fail until valid credentials are provided."
+                )
             else:
                 raise
-    
+
     def set_token(self, token: str, single_tenant: bool = False) -> None:
         """Set the access token.
 
@@ -197,11 +210,15 @@ class NormanAPI:
 
         # If we already have a token from direct login, don't override it with OAuth token
         if self.token_source == "direct_login":
-            logger.info("Keeping existing direct login token instead of setting OAuth token")
+            logger.info(
+                "Keeping existing direct login token instead of setting OAuth token"
+            )
             return
 
         if single_tenant:
-            logger.info("Setting Norman API token from credential login (single tenant)")
+            logger.info(
+                "Setting Norman API token from credential login (single tenant)"
+            )
             self.access_token = token
             self.token_source = "env"
             try:
@@ -224,46 +241,53 @@ class NormanAPI:
         # `company_id` property resolves lazily instead -- which also spares an
         # API round trip on requests that never need a company.
 
-
     def authenticate(self) -> None:
         """Authenticate with Norman Finance API and get access token."""
         if not config.NORMAN_EMAIL or not config.NORMAN_PASSWORD:
-            raise ValueError("Norman Finance credentials not set. Please set NORMAN_EMAIL and NORMAN_PASSWORD environment variables.")
-        
+            raise ValueError(
+                "Norman Finance credentials not set. Please set NORMAN_EMAIL and NORMAN_PASSWORD environment variables."
+            )
+
         # Extract username from email (as per instructions)
-        username = config.NORMAN_EMAIL.split('@')[0]
+        username = config.NORMAN_EMAIL.split("@")[0]
         auth_url = urljoin(config.api_base_url, "api/v1/auth/token/")
-        
+
         payload = {
             "username": username,
             "email": config.NORMAN_EMAIL,
-            "password": config.NORMAN_PASSWORD
+            "password": config.NORMAN_PASSWORD,
         }
-        
+
         try:
-            response = requests.post(auth_url, json=payload, timeout=config.NORMAN_API_TIMEOUT)
+            response = requests.post(
+                auth_url, json=payload, timeout=config.NORMAN_API_TIMEOUT
+            )
             response.raise_for_status()
-            
+
             auth_data = response.json()
             self.access_token = auth_data.get("access")
             self.refresh_token = auth_data.get("refresh")
             self.token_source = "env"
-            
+
             # Get company ID (user typically has only one company)
             self._set_company_id()
-            
-            logger.info("Successfully authenticated with Norman Finance API using environment credentials")
+
+            logger.info(
+                "Successfully authenticated with Norman Finance API using environment credentials"
+            )
         except requests.exceptions.RequestException as e:
             logger.error(f"Failed to authenticate with Norman Finance API: {str(e)}")
-            if hasattr(e, 'response') and e.response is not None:
+            if hasattr(e, "response") and e.response is not None:
                 logger.error(f"Response: {e.response.text}")
             raise
-    
+
     def _set_company_id(self) -> None:
         """Resolve and store the company id for the env/stdio token."""
         self.company_id = self._fetch_company_id(self.access_token)
 
-    def _fetch_company_id(self, token: Optional[str], _refreshed: bool = False) -> Optional[str]:
+    def _fetch_company_id(
+        self, token: Optional[str], _refreshed: bool = False
+    ) -> Optional[str]:
         """Look up the first company for `token`'s owner.
 
         Pure in the token: it stores nothing on `self`, so it is safe to call
@@ -290,13 +314,11 @@ class NormanAPI:
             headers = {
                 "Authorization": f"Bearer {token}",
                 "User-Agent": "NormanMCPServer/0.1.0",
-                "X-Requested-With": "XMLHttpRequest"
+                "X-Requested-With": "XMLHttpRequest",
             }
-            
+
             response = requests.get(
-                companies_url,
-                headers=headers,
-                timeout=config.NORMAN_API_TIMEOUT
+                companies_url, headers=headers, timeout=config.NORMAN_API_TIMEOUT
             )
 
             if response.status_code == 401 and not _refreshed:
@@ -311,9 +333,9 @@ class NormanAPI:
 
             response.raise_for_status()
             response_data = response.json()
-            
+
             companies = response_data.get("results", [])
-            
+
             if not companies:
                 logger.warning("No companies found for user")
                 return None
@@ -349,10 +371,14 @@ class NormanAPI:
         logger.info("Norman token expired during company lookup; refreshing")
         return self._refresh_oauth_norman_token()
 
-
-    def _make_request(self, method: str, url: str, params: Optional[Dict[str, Any]] = None, 
-                     json_data: Optional[Dict[str, Any]] = None, 
-                     files: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def _make_request(
+        self,
+        method: str,
+        url: str,
+        params: Optional[Dict[str, Any]] = None,
+        json_data: Optional[Dict[str, Any]] = None,
+        files: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         """Make a request to the Norman Finance API with security controls."""
         # Resolve the caller's token for THIS request. Keep it in a local: it
         # must never be written to `self`, which is shared across users.
@@ -361,16 +387,22 @@ class NormanAPI:
         # No token and single-tenant mode: env credentials are the last resort.
         if not token and self.token_source == "env":
             try:
-                logger.warning("No Norman token available. Attempting authentication with environment variables...")
+                logger.warning(
+                    "No Norman token available. Attempting authentication with environment variables..."
+                )
                 self.authenticate()
                 token = self.access_token
             except Exception as e:
                 logger.error(f"Authentication failed: {str(e)}")
-                return {"error": "No authentication token available. Please authenticate first."}
+                return {
+                    "error": "No authentication token available. Please authenticate first."
+                }
 
         if not token:
             logger.error("No Norman token resolvable for this request")
-            return {"error": "No authentication token available. Please authenticate first."}
+            return {
+                "error": "No authentication token available. Please authenticate first."
+            }
 
         # Validate URL to prevent SSRF attacks
         if not validate_url(url):
@@ -384,11 +416,13 @@ class NormanAPI:
             "X-Requested-With": "XMLHttpRequest",
             # Security headers
             "X-Content-Type-Options": "nosniff",
-            "X-Frame-Options": "DENY"
+            "X-Frame-Options": "DENY",
         }
 
         # Log token source for debugging
-        logger.debug(f"Making API request to {url} with token source: {self.token_source}")
+        logger.debug(
+            f"Making API request to {url} with token source: {self.token_source}"
+        )
 
         if params is None:
             params = {}
@@ -412,7 +446,7 @@ class NormanAPI:
                 else:
                     sanitized_params[key] = value
             params = sanitized_params
-        
+
         # Sanitize JSON data to prevent injection
         if json_data:
             sanitized_json = {}
@@ -431,7 +465,7 @@ class NormanAPI:
                 else:
                     sanitized_json[key] = value
             json_data = sanitized_json
-        
+
         try:
             if files and json_data:
                 response = requests.request(
@@ -441,7 +475,7 @@ class NormanAPI:
                     params=params,
                     data=json_data,
                     files=files,
-                    timeout=config.NORMAN_API_TIMEOUT
+                    timeout=config.NORMAN_API_TIMEOUT,
                 )
             else:
                 response = requests.request(
@@ -451,10 +485,10 @@ class NormanAPI:
                     params=params,
                     json=json_data,
                     files=files,
-                    timeout=config.NORMAN_API_TIMEOUT
+                    timeout=config.NORMAN_API_TIMEOUT,
                 )
             response.raise_for_status()
-            
+
             # Attempt to parse JSON response, but handle non-JSON responses gracefully
             try:
                 if response.content:
@@ -462,11 +496,11 @@ class NormanAPI:
                 return {}
             except ValueError:
                 # Not JSON, return content as string if it's not binary
-                if response.headers.get('content-type', '').startswith('text/'):
+                if response.headers.get("content-type", "").startswith("text/"):
                     return {"content": response.text}
                 # For binary content, return success message
                 return {"success": True, "message": "Request successful"}
-                
+
         except requests.exceptions.HTTPError as e:
             # Handle token expiration
             if e.response.status_code == 401:
@@ -502,23 +536,32 @@ class NormanAPI:
                 }
             elif e.response.status_code == 403:
                 logger.error("Access forbidden. Check your account permissions.")
-                return {"error": "Access forbidden. Check your account permissions.", "status_code": 403}
+                return {
+                    "error": "Access forbidden. Check your account permissions.",
+                    "status_code": 403,
+                }
             elif e.response.status_code == 404:
                 logger.error(f"Resource not found: {url}")
                 return {"error": "Resource not found", "status_code": 404}
             elif e.response.status_code == 429:
                 logger.error("Rate limit exceeded. Please try again later.")
-                return {"error": "Rate limit exceeded. Please try again later.", "status_code": 429}
+                return {
+                    "error": "Rate limit exceeded. Please try again later.",
+                    "status_code": 429,
+                }
             else:
                 logger.error(f"HTTP error: {str(e)}")
                 error_detail = None
-                if hasattr(e, 'response') and e.response is not None:
+                if hasattr(e, "response") and e.response is not None:
                     logger.error(f"Response: {e.response.text}")
                     try:
                         error_detail = e.response.json()
                     except (ValueError, AttributeError):
                         error_detail = e.response.text
-                result = {"error": f"Request failed: {str(e)}", "status_code": e.response.status_code}
+                result = {
+                    "error": f"Request failed: {str(e)}",
+                    "status_code": e.response.status_code,
+                }
                 if error_detail:
                     result["detail"] = error_detail
                 return result
@@ -534,6 +577,24 @@ class NormanAPI:
         except Exception as e:
             logger.error(f"Unexpected error making request to {url}: {str(e)}")
             return {"error": f"Unexpected error: {str(e)}"}
+
+    async def arequest(
+        self,
+        method: str,
+        url: str,
+        params: Optional[Dict[str, Any]] = None,
+        json_data: Optional[Dict[str, Any]] = None,
+        files: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Run the blocking requests client off the MCP event loop."""
+        return await asyncio.to_thread(
+            self._make_request,
+            method,
+            url,
+            params,
+            json_data,
+            files,
+        )
 
     def _refresh_oauth_norman_token(self) -> Optional[str]:
         """Refresh the Norman access token for the current MCP request (OAuth).

--- a/norman_mcp/server.py
+++ b/norman_mcp/server.py
@@ -23,6 +23,7 @@ from mcp.server.auth.settings import AuthSettings, ClientRegistrationOptions
 from mcp.server.auth.routes import validate_issuer_url
 
 from norman_mcp.api.client import NormanAPI
+from norman_mcp.tools.accounting import register_accounting_tools
 from norman_mcp.tools.clients import register_client_tools
 from norman_mcp.tools.vendors import register_vendor_tools
 from norman_mcp.tools.bills import register_bill_tools
@@ -359,6 +360,7 @@ def create_app(host=None, port=None, public_url=None, transport="sse", streamabl
     register_offer_tools(server)
     register_tax_tools(server)
     register_transaction_tools(server)
+    register_accounting_tools(server)
     register_rule_tools(server)
     register_document_tools(server)
     register_company_tools(server)

--- a/norman_mcp/tools/accounting.py
+++ b/norman_mcp/tools/accounting.py
@@ -1,0 +1,768 @@
+"""MCP tools for Norman's SME Accounting workspace.
+
+The UI, internal assistant and public MCP connector must all use the same REST
+endpoints.  This module deliberately contains no accounting calculations: the
+Ledger remains the source of truth and the API remains the only writer.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from urllib.parse import urljoin
+
+from mcp.types import ToolAnnotations
+from pydantic import Field
+
+from norman_mcp import config
+from norman_mcp.context import Context
+
+
+READ_ONLY = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+)
+WRITE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=False,
+    openWorldHint=False,
+)
+DESTRUCTIVE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=True,
+    idempotentHint=False,
+    openWorldHint=False,
+)
+
+
+def _api_and_company(
+    ctx: Context,
+) -> tuple[Any, Optional[str], Optional[Dict[str, Any]]]:
+    api = ctx.request_context.lifespan_context["api"]
+    company_id = api.company_id
+    if not company_id:
+        return (
+            api,
+            None,
+            {
+                "error": "No company available. Please authenticate and select a company first."
+            },
+        )
+    return api, company_id, None
+
+
+async def _request(
+    api: Any,
+    method: str,
+    url: str,
+    *,
+    params: Optional[Dict[str, Any]] = None,
+    json_data: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Use the non-blocking client in both the embedded and standalone MCP."""
+    return await api.arequest(method, url, params=params, json_data=json_data)
+
+
+def _company_url(company_id: str, suffix: str) -> str:
+    return urljoin(
+        config.api_base_url, f"api/v1/companies/{company_id}/{suffix.lstrip('/')}"
+    )
+
+
+def _compact(data: Dict[str, Any]) -> Dict[str, Any]:
+    return {key: value for key, value in data.items() if value is not None}
+
+
+def register_accounting_tools(mcp: Any) -> None:
+    """Register Assets, Ledger, Chart of Accounts and year setup tools."""
+
+    @mcp.tool(title="Get Accounting Setup", annotations=READ_ONLY)
+    async def get_accounting_setup(
+        ctx: Context,
+        fiscal_year_begin: str = Field(
+            description="Fiscal-year start in YYYY-MM-DD format"
+        ),
+        fiscal_year_end: str = Field(
+            description="Fiscal-year end in YYYY-MM-DD format"
+        ),
+    ) -> Dict[str, Any]:
+        """Get opening/cutover status for a fiscal year without changing the books."""
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        url = _company_url(company_id, "accounting/cutover/")
+        return await _request(
+            api,
+            "GET",
+            url,
+            params={
+                "fiscalYearBegin": fiscal_year_begin,
+                "fiscalYearEnd": fiscal_year_end,
+            },
+        )
+
+    @mcp.tool(title="List Chart of Accounts Templates", annotations=READ_ONLY)
+    async def list_chart_of_accounts_templates(ctx: Context) -> Dict[str, Any]:
+        """List account frameworks available for the selected company and country."""
+        api, _company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        url = urljoin(
+            config.api_base_url, "api/v1/accounting/company-categories/templates/"
+        )
+        return await _request(api, "GET", url)
+
+    @mcp.tool(title="List Chart of Accounts", annotations=READ_ONLY)
+    async def list_chart_of_accounts(
+        ctx: Context,
+        search: Optional[str] = Field(
+            default=None, description="Search account code or localized name"
+        ),
+        code: Optional[str] = Field(default=None, description="Exact account code"),
+        account_type: Optional[str] = Field(
+            default=None,
+            description="ASSET, LIABILITY, EQUITY, INCOME or EXPENSE",
+        ),
+        availability: Optional[str] = Field(
+            default=None,
+            description="TRANSACTIONS or LEDGER_ONLY",
+        ),
+        status: Optional[str] = Field(
+            default="ACTIVE", description="ACTIVE or INACTIVE"
+        ),
+        origin: Optional[str] = Field(default=None, description="SYSTEM or CUSTOM"),
+        ordering: str = Field(
+            default="code",
+            description="code, -code, name, -name, accountType or -accountType",
+        ),
+        page: int = Field(default=1, ge=1),
+        page_size: int = Field(default=50, ge=1, le=200),
+    ) -> Dict[str, Any]:
+        """Search and page through the selected company's complete account master."""
+        api, _company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        url = urljoin(config.api_base_url, "api/v1/accounting/company-categories/")
+        params = _compact(
+            {
+                "search": search,
+                "code": code,
+                "accountType": account_type,
+                "availability": availability,
+                "status": status,
+                "origin": origin,
+                "ordering": ordering,
+                "page": page,
+                "pageSize": page_size,
+                "includeInactive": status == "INACTIVE",
+                "includeStatementOnly": True,
+            }
+        )
+        return await _request(api, "GET", url, params=params)
+
+    @mcp.tool(title="Create Chart of Accounts Account", annotations=WRITE)
+    async def create_chart_of_accounts_account(
+        ctx: Context,
+        code: str = Field(description="Unique account code in the selected framework"),
+        name: str = Field(description="User-facing account name"),
+        account_type: str = Field(
+            description="ASSET, LIABILITY, EQUITY, INCOME or EXPENSE"
+        ),
+        available_in_transactions: bool = Field(
+            default=False,
+            description="Whether this account may also be assigned to day-to-day Transactions",
+        ),
+        description: str = Field(
+            default="", description="Optional accounting purpose or usage note"
+        ),
+        vat_applicable: bool = Field(default=False),
+        suggested_vat_rate: int = Field(default=0, ge=0, le=100),
+    ) -> Dict[str, Any]:
+        """Create a custom Ledger account; balance-sheet accounts stay Ledger-only."""
+        api, _company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        url = urljoin(config.api_base_url, "api/v1/accounting/company-categories/")
+        payload = {
+            "code": code,
+            "name": name,
+            "cashflowType": account_type,
+            "isBookable": available_in_transactions,
+            "description": description,
+            "vatApplicability": vat_applicable,
+            "suggestedVatRate": suggested_vat_rate,
+        }
+        return await _request(api, "POST", url, json_data=payload)
+
+    @mcp.tool(title="Update Chart of Accounts Account", annotations=WRITE)
+    async def update_chart_of_accounts_account(
+        ctx: Context,
+        account_id: str = Field(
+            description="Account public ID from list_chart_of_accounts"
+        ),
+        name: Optional[str] = None,
+        account_type: Optional[str] = Field(
+            default=None, description="ASSET, LIABILITY, EQUITY, INCOME or EXPENSE"
+        ),
+        available_in_transactions: Optional[bool] = None,
+        active: Optional[bool] = None,
+        description: Optional[str] = None,
+        vat_applicable: Optional[bool] = None,
+        suggested_vat_rate: Optional[int] = Field(default=None, ge=0, le=100),
+    ) -> Dict[str, Any]:
+        """Edit a custom account, or hide/unhide a built-in account."""
+        api, _company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        url = urljoin(
+            config.api_base_url, f"api/v1/accounting/company-categories/{account_id}/"
+        )
+        payload = _compact(
+            {
+                "name": name,
+                "cashflowType": account_type,
+                "isBookable": available_in_transactions,
+                "isActive": active,
+                "description": description,
+                "vatApplicability": vat_applicable,
+                "suggestedVatRate": suggested_vat_rate,
+            }
+        )
+        return await _request(api, "PATCH", url, json_data=payload)
+
+    @mcp.tool(title="Deactivate Chart of Accounts Account", annotations=DESTRUCTIVE)
+    async def deactivate_chart_of_accounts_account(
+        ctx: Context,
+        account_id: str = Field(
+            description="Account public ID from list_chart_of_accounts"
+        ),
+        confirmed: bool = Field(
+            default=False,
+            description="Must be true after the user confirms the account should be hidden",
+        ),
+    ) -> Dict[str, Any]:
+        """Soft-delete an account. Existing postings remain in the immutable Ledger."""
+        if not confirmed:
+            return {
+                "confirmationRequired": True,
+                "warning": "This hides the account from future selection. Existing Ledger postings remain unchanged.",
+            }
+        api, _company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        url = urljoin(
+            config.api_base_url, f"api/v1/accounting/company-categories/{account_id}/"
+        )
+        return await _request(api, "DELETE", url)
+
+    @mcp.tool(title="Switch Account Framework", annotations=DESTRUCTIVE)
+    async def switch_account_framework(
+        ctx: Context,
+        framework_code: str = Field(
+            description="Template code, for example skr03 or skr04"
+        ),
+        confirmed: bool = Field(
+            default=False,
+            description="Must be true only after the user explicitly accepts the remapping risk",
+        ),
+    ) -> Dict[str, Any]:
+        """Switch SKR framework with the same explicit confirmation used by the Norman UI."""
+        warning = (
+            "Switching the account framework provisions a different system account master. "
+            "Custom accounts are preserved, but existing transaction account assignments and "
+            "reports may require review. The operation is not a casual navigation choice."
+        )
+        if not confirmed:
+            return {"confirmationRequired": True, "warning": warning}
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        url = _company_url(company_id, "")
+        return await _request(
+            api,
+            "PATCH",
+            url,
+            json_data={
+                "chartOfAccounts": framework_code,
+                "confirmChartOfAccountsSwitch": True,
+            },
+        )
+
+    @mcp.tool(title="List Assets", annotations=READ_ONLY)
+    async def list_assets(
+        ctx: Context, page: int = Field(default=1, ge=1)
+    ) -> Dict[str, Any]:
+        """List fixed assets and their depreciation schedules."""
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        return await _request(
+            api,
+            "GET",
+            _company_url(company_id, "accounting/assets/"),
+            params={"page": page},
+        )
+
+    @mcp.tool(title="Get Asset", annotations=READ_ONLY)
+    async def get_asset(ctx: Context, asset_id: str) -> Dict[str, Any]:
+        """Get an asset including source transaction, useful life and annual depreciation."""
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        return await _request(
+            api, "GET", _company_url(company_id, f"accounting/assets/{asset_id}/")
+        )
+
+    @mcp.tool(title="Create Asset", annotations=WRITE)
+    async def create_asset(
+        ctx: Context,
+        name: str,
+        asset_type: str = Field(description="tangible or intangible"),
+        acquisition_date: str = Field(
+            description="Original acquisition date in YYYY-MM-DD format"
+        ),
+        depreciation_basis: float = Field(
+            gt=0, description="Net basis, or gross when input VAT is not deductible"
+        ),
+        useful_lifetime_months: int = Field(gt=0),
+        gross_purchase_price: Optional[float] = None,
+        business_use_percent: float = Field(default=100, ge=0, le=100),
+        ledger_account_code: Optional[str] = None,
+        transaction_id: Optional[str] = None,
+        transaction_item_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Create an asset, optionally linked to a Norman Transaction or split item."""
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        payload = _compact(
+            {
+                "name": name,
+                "type": asset_type,
+                "status": "active",
+                "date": acquisition_date,
+                "depreciationDate": acquisition_date,
+                "amount": depreciation_basis,
+                "amountIncVat": gross_purchase_price,
+                # The public form speaks in percentages; the Asset model stores a
+                # fraction (1.00 == 100%). Keep that conversion at the MCP edge so
+                # agents cannot accidentally create a 100x depreciation basis.
+                "useProfessionalPart": business_use_percent / 100,
+                "usefulLifetime": useful_lifetime_months,
+                "amortizationMethod": "straightLine",
+                "ledgerAccountCode": ledger_account_code,
+                "transaction": transaction_id,
+                "transactionItem": transaction_item_id,
+            }
+        )
+        return await _request(
+            api,
+            "POST",
+            _company_url(company_id, "accounting/assets/"),
+            json_data=payload,
+        )
+
+    @mcp.tool(title="Update Asset", annotations=WRITE)
+    async def update_asset(
+        ctx: Context,
+        asset_id: str,
+        name: Optional[str] = None,
+        acquisition_date: Optional[str] = None,
+        depreciation_basis: Optional[float] = Field(default=None, gt=0),
+        gross_purchase_price: Optional[float] = None,
+        useful_lifetime_months: Optional[int] = Field(default=None, gt=0),
+        business_use_percent: Optional[float] = Field(default=None, ge=0, le=100),
+        ledger_account_code: Optional[str] = None,
+        status: Optional[str] = Field(default=None, description="active, lost or sold"),
+    ) -> Dict[str, Any]:
+        """Edit an asset through the audited Asset service."""
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        payload = _compact(
+            {
+                "name": name,
+                "date": acquisition_date,
+                "depreciationDate": acquisition_date,
+                "amount": depreciation_basis,
+                "amountIncVat": gross_purchase_price,
+                "usefulLifetime": useful_lifetime_months,
+                "useProfessionalPart": business_use_percent / 100
+                if business_use_percent is not None
+                else None,
+                "ledgerAccountCode": ledger_account_code,
+                "status": status,
+            }
+        )
+        return await _request(
+            api,
+            "PATCH",
+            _company_url(company_id, f"accounting/assets/{asset_id}/"),
+            json_data=payload,
+        )
+
+    @mcp.tool(title="Delete Asset", annotations=DESTRUCTIVE)
+    async def delete_asset(
+        ctx: Context, asset_id: str, confirmed: bool = False
+    ) -> Dict[str, Any]:
+        """Delete an asset only after explicit confirmation; audit/reversal rules remain server-side."""
+        if not confirmed:
+            return {
+                "confirmationRequired": True,
+                "warning": "Deleting an asset affects its depreciation schedule. Confirm after reviewing the asset.",
+            }
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        return await _request(
+            api, "DELETE", _company_url(company_id, f"accounting/assets/{asset_id}/")
+        )
+
+    @mcp.tool(title="List Ledger Journal", annotations=READ_ONLY)
+    async def list_ledger_journal(
+        ctx: Context,
+        date_from: Optional[str] = None,
+        date_to: Optional[str] = None,
+        account: Optional[str] = None,
+        source: Optional[str] = None,
+        tax_treatment: Optional[str] = None,
+        search: Optional[str] = None,
+        ordering: str = Field(
+            default="date_desc", description="Defaults to newest first"
+        ),
+        page: int = Field(default=1, ge=1),
+    ) -> Dict[str, Any]:
+        """Read the chronological double-entry audit trail with source and tax-treatment filters."""
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        params = _compact(
+            {
+                "dateFrom": date_from,
+                "dateTo": date_to,
+                "account": account,
+                "source": source,
+                "taxTreatment": tax_treatment,
+                "search": search,
+                "ordering": ordering,
+                "page": page,
+            }
+        )
+        return await _request(
+            api,
+            "GET",
+            _company_url(company_id, "accounting/ledger/journal/"),
+            params=params,
+        )
+
+    @mcp.tool(title="List Ledger Account Balances", annotations=READ_ONLY)
+    async def list_ledger_account_balances(
+        ctx: Context,
+        date_from: Optional[str] = None,
+        date_to: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Return the SuSa: debit, credit and saldo for every used account."""
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        return await _request(
+            api,
+            "GET",
+            _company_url(company_id, "accounting/ledger/accounts/"),
+            params=_compact({"dateFrom": date_from, "dateTo": date_to}),
+        )
+
+    @mcp.tool(title="Get Ledger Account", annotations=READ_ONLY)
+    async def get_ledger_account(
+        ctx: Context,
+        account_code: str,
+        date_from: Optional[str] = None,
+        date_to: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Return a Kontenblatt with postings and a running balance for one account."""
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        return await _request(
+            api,
+            "GET",
+            _company_url(company_id, f"accounting/ledger/accounts/{account_code}/"),
+            params=_compact({"dateFrom": date_from, "dateTo": date_to}),
+        )
+
+    @mcp.tool(title="List Ledger Open Items", annotations=READ_ONLY)
+    async def list_ledger_open_items(
+        ctx: Context,
+        date_from: Optional[str] = None,
+        date_to: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Return the derived debtor/creditor open-item list and ageing."""
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        return await _request(
+            api,
+            "GET",
+            _company_url(company_id, "accounting/ledger/open-items/"),
+            params=_compact({"dateFrom": date_from, "dateTo": date_to}),
+        )
+
+    @mcp.tool(title="Get Cash Book", annotations=READ_ONLY)
+    async def get_cash_book(
+        ctx: Context,
+        year: int = Field(ge=2000, le=2100),
+        month: Optional[int] = Field(default=None, ge=1, le=12),
+    ) -> Dict[str, Any]:
+        """Read the cash register derived from CASH transactions and the Kasse account."""
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        return await _request(
+            api,
+            "GET",
+            _company_url(company_id, "accounting/cash-book/"),
+            params=_compact({"year": year, "month": month}),
+        )
+
+    async def _statement(
+        ctx: Context,
+        endpoint: str,
+        date_from: str,
+        date_to: str,
+        period_type: str,
+        previous_date_from: Optional[str],
+        previous_date_to: Optional[str],
+    ) -> Dict[str, Any]:
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        return await _request(
+            api,
+            "GET",
+            _company_url(company_id, endpoint),
+            params=_compact(
+                {
+                    "dateFrom": date_from,
+                    "dateTo": date_to,
+                    "periodType": period_type,
+                    "previousDateFrom": previous_date_from,
+                    "previousDateTo": previous_date_to,
+                }
+            ),
+        )
+
+    @mcp.tool(title="Get Ledger Profit and Loss", annotations=READ_ONLY)
+    async def get_ledger_profit_and_loss(
+        ctx: Context,
+        date_from: str,
+        date_to: str,
+        period_type: str = Field(default="year", description="month, quarter or year"),
+        previous_date_from: Optional[str] = None,
+        previous_date_to: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Get GuV/P&L calculated exclusively from materialized Ledger postings."""
+        return await _statement(
+            ctx,
+            "accounting/ledger/profit-loss/",
+            date_from,
+            date_to,
+            period_type,
+            previous_date_from,
+            previous_date_to,
+        )
+
+    @mcp.tool(title="Get Ledger Balance Sheet", annotations=READ_ONLY)
+    async def get_ledger_balance_sheet(
+        ctx: Context,
+        date_from: str,
+        date_to: str,
+        period_type: str = Field(default="year", description="month, quarter or year"),
+        previous_date_from: Optional[str] = None,
+        previous_date_to: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Get the balance sheet using the same mappings as Annual Close and E-Bilanz."""
+        return await _statement(
+            ctx,
+            "accounting/ledger/balance-sheet/",
+            date_from,
+            date_to,
+            period_type,
+            previous_date_from,
+            previous_date_to,
+        )
+
+    @mcp.tool(title="Create Manual Ledger Entry", annotations=WRITE)
+    async def create_manual_ledger_entry(
+        ctx: Context,
+        booking_date: str,
+        debit_code: str,
+        credit_code: str,
+        amount: float = Field(gt=0),
+        memo: str = "",
+        tax_treatment: str = "NONE",
+        tax_country_scope: str = "UNKNOWN",
+        tax_rate: Optional[float] = Field(default=None, ge=0, le=100),
+        input_tax_deduction_percent: Optional[float] = Field(
+            default=None, ge=0, le=100
+        ),
+    ) -> Dict[str, Any]:
+        """Create a balanced manual posting with explicit tax semantics."""
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        payload = _compact(
+            {
+                "bookingDate": booking_date,
+                "debitCode": debit_code,
+                "creditCode": credit_code,
+                "amount": amount,
+                "memo": memo,
+                "taxTreatment": tax_treatment,
+                "taxCountryScope": tax_country_scope,
+                "taxRate": tax_rate,
+                "inputTaxDeductionPercent": input_tax_deduction_percent,
+            }
+        )
+        return await _request(
+            api,
+            "POST",
+            _company_url(company_id, "accounting/ledger/manual-entries/"),
+            json_data=payload,
+        )
+
+    @mcp.tool(title="Get Manual Ledger Entry", annotations=READ_ONLY)
+    async def get_manual_ledger_entry(ctx: Context, entry_id: str) -> Dict[str, Any]:
+        """Get a manual posting and its immutable reversal links."""
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        return await _request(
+            api,
+            "GET",
+            _company_url(company_id, f"accounting/ledger/manual-entries/{entry_id}/"),
+        )
+
+    @mcp.tool(title="Reverse Manual Ledger Entry", annotations=DESTRUCTIVE)
+    async def reverse_manual_ledger_entry(
+        ctx: Context,
+        entry_id: str,
+        confirmed: bool = Field(
+            default=False,
+            description="Must be true after reviewing the original posting",
+        ),
+        booking_date: Optional[str] = None,
+        memo: str = "",
+    ) -> Dict[str, Any]:
+        """Correct a manual posting by Storno; the original entry is never deleted or edited."""
+        if not confirmed:
+            return {
+                "confirmationRequired": True,
+                "warning": "This creates an immutable Storno with debit and credit reversed.",
+            }
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        return await _request(
+            api,
+            "POST",
+            _company_url(
+                company_id, f"accounting/ledger/manual-entries/{entry_id}/reverse/"
+            ),
+            json_data=_compact({"bookingDate": booking_date, "memo": memo}),
+        )
+
+    @mcp.tool(title="List Annual Closes", annotations=READ_ONLY)
+    async def list_annual_closes(ctx: Context) -> Dict[str, Any]:
+        """List fiscal-year close workspaces and their current status."""
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        return await _request(
+            api, "GET", _company_url(company_id, "accounting/annual-closes/")
+        )
+
+    @mcp.tool(title="Create Annual Close", annotations=WRITE)
+    async def create_annual_close(
+        ctx: Context,
+        fiscal_year_begin: str = Field(
+            description="Fiscal-year start in YYYY-MM-DD format"
+        ),
+        fiscal_year_end: str = Field(
+            description="Fiscal-year end in YYYY-MM-DD format"
+        ),
+    ) -> Dict[str, Any]:
+        """Create a Draft annual-close workspace; this does not lock or submit the year."""
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        return await _request(
+            api,
+            "POST",
+            _company_url(company_id, "accounting/annual-closes/"),
+            json_data={
+                "fiscalYearBegin": fiscal_year_begin,
+                "fiscalYearEnd": fiscal_year_end,
+            },
+        )
+
+    @mcp.tool(title="Get Annual Close", annotations=READ_ONLY)
+    async def get_annual_close(ctx: Context, annual_close_id: str) -> Dict[str, Any]:
+        """Get one annual-close workspace and its Draft/locked/submitted status."""
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        return await _request(
+            api,
+            "GET",
+            _company_url(company_id, f"accounting/annual-closes/{annual_close_id}/"),
+        )
+
+    @mcp.tool(title="Create Annual Close Entry", annotations=WRITE)
+    async def create_annual_close_entry(
+        ctx: Context,
+        annual_close_id: str,
+        debit_code: str,
+        credit_code: str,
+        amount: float = Field(gt=0),
+        memo: str = "",
+        booking_date: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Post a closing adjustment to a Draft annual close; locked years remain server-protected."""
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        return await _request(
+            api,
+            "POST",
+            _company_url(
+                company_id, f"accounting/annual-closes/{annual_close_id}/entries/"
+            ),
+            json_data=_compact(
+                {
+                    "debitCode": debit_code,
+                    "creditCode": credit_code,
+                    "amount": amount,
+                    "memo": memo,
+                    "bookingDate": booking_date,
+                    "source": "CLOSING",
+                }
+            ),
+        )
+
+    @mcp.tool(title="Get Annual Close Workbook", annotations=READ_ONLY)
+    async def get_annual_close_workbook(
+        ctx: Context, annual_close_id: str
+    ) -> Dict[str, Any]:
+        """Review SuSa, Bilanz, GuV, BVV and blocking validations. This never locks or submits."""
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        return await _request(
+            api,
+            "GET",
+            _company_url(
+                company_id, f"accounting/annual-closes/{annual_close_id}/workbook/"
+            ),
+        )

--- a/norman_mcp/tools/transactions.py
+++ b/norman_mcp/tools/transactions.py
@@ -10,9 +10,45 @@ from norman_mcp import config
 
 logger = logging.getLogger(__name__)
 
+ITEMS_TOTAL_TOLERANCE = 0.02
+
+
+def _build_items_payload(items: List[dict], *, negate: bool) -> List[dict]:
+    """Translate positive document lines into the transaction API's signed rows."""
+    payload = []
+    for order, item in enumerate(items):
+        amount = abs(float(item.get("amount") or 0))
+        entry: Dict[str, Any] = {
+            "description": str(item.get("description") or ""),
+            "amount": -amount if negate else amount,
+            "vatRate": item.get("vat_rate"),
+            "vatType": item.get("vat_type") or "VAT_INCLUDED",
+            "order": order,
+        }
+        if item.get("category_id"):
+            entry["category"] = item["category_id"]
+        if item.get("company_category_id"):
+            entry["companyCategory"] = item["company_category_id"]
+        payload.append(entry)
+    return payload
+
+
+def _items_total_mismatch(items: List[dict], amount: float) -> Optional[Dict[str, Any]]:
+    items_total = sum(abs(float(item.get("amount") or 0)) for item in items)
+    difference = abs(items_total - abs(amount))
+    if difference <= ITEMS_TOTAL_TOLERANCE * max(len(items), 1):
+        return None
+    return {
+        "error": (
+            f"The line items add up to {items_total:.2f}, but the stated total is "
+            f"{abs(amount):.2f}. Re-read the document and fix the complete split."
+        ),
+    }
+
+
 def register_transaction_tools(mcp):
     """Register all transaction-related tools with the MCP server."""
-    
+
     @mcp.tool(
         title="Search Transactions",
         annotations=ToolAnnotations(
@@ -24,21 +60,45 @@ def register_transaction_tools(mcp):
     )
     async def search_transactions(
         ctx: Context,
-        description: Optional[str] = Field(default=None, description="Text to search for in transaction descriptions"),
-        from_date: Optional[str] = Field(default=None, description="Start date in YYYY-MM-DD format"),
-        to_date: Optional[str] = Field(default=None, description="End date in YYYY-MM-DD format"),
-        min_amount: Optional[float] = Field(default=None, description="Minimum transaction amount"),
-        max_amount: Optional[float] = Field(default=None, description="Maximum transaction amount"),
-        category: Optional[str] = Field(default=None, description="Transaction category"),
-        no_invoice: Optional[bool] = Field(default=None, description="Whether to exclude invoices"),
-        no_receipt: Optional[bool] = Field(default=None, description="Whether to exclude receipts"),
-        status: Optional[str] = Field(default=None, description="Status of the transaction (UNVERIFIED, VERIFIED)"),
-        cashflow_type: Optional[str] = Field(default=None, description="Cashflow type of the transaction (INCOME, EXPENSE)"),
-        limit: Optional[int] = Field(default=None, description="Maximum number of results to return (default 100)")
+        description: Optional[str] = Field(
+            default=None, description="Text to search for in transaction descriptions"
+        ),
+        from_date: Optional[str] = Field(
+            default=None, description="Start date in YYYY-MM-DD format"
+        ),
+        to_date: Optional[str] = Field(
+            default=None, description="End date in YYYY-MM-DD format"
+        ),
+        min_amount: Optional[float] = Field(
+            default=None, description="Minimum transaction amount"
+        ),
+        max_amount: Optional[float] = Field(
+            default=None, description="Maximum transaction amount"
+        ),
+        category: Optional[str] = Field(
+            default=None, description="Transaction category"
+        ),
+        no_invoice: Optional[bool] = Field(
+            default=None, description="Whether to exclude invoices"
+        ),
+        no_receipt: Optional[bool] = Field(
+            default=None, description="Whether to exclude receipts"
+        ),
+        status: Optional[str] = Field(
+            default=None, description="Status of the transaction (UNVERIFIED, VERIFIED)"
+        ),
+        cashflow_type: Optional[str] = Field(
+            default=None,
+            description="Cashflow type of the transaction (INCOME, EXPENSE)",
+        ),
+        limit: Optional[int] = Field(
+            default=None,
+            description="Maximum number of results to return (default 100)",
+        ),
     ) -> Dict[str, Any]:
         """
         Search for transactions matching specified criteria.
-        
+
         Args:
             description: Text to search for in transaction descriptions
             from_date: Start date in YYYY-MM-DD format
@@ -51,21 +111,21 @@ def register_transaction_tools(mcp):
             no_receipt: Whether to exclude receipts
             status: Status of the transaction (UNVERIFIED, VERIFIED)
             cashflow_type: Cashflow type of the transaction (INCOME, EXPENSE)
-            
+
         Returns:
             List of matching transactions with sensitive data removed
         """
         api = ctx.request_context.lifespan_context["api"]
         company_id = api.company_id
-        
+
         if not company_id:
             return {"error": "No company available. Please authenticate first."}
-        
+
         transactions_url = urljoin(
-            config.api_base_url, 
-            f"api/v1/companies/{company_id}/accounting/transactions/"
+            config.api_base_url,
+            f"api/v1/companies/{company_id}/accounting/transactions/",
         )
-        
+
         # Build query parameters
         params = {}
         if description:
@@ -90,8 +150,34 @@ def register_transaction_tools(mcp):
             params["cashflowType"] = cashflow_type
         if limit:
             params["limit"] = limit
-        
-        return api._make_request("GET", transactions_url, params=params)
+
+        return await api.arequest("GET", transactions_url, params=params)
+
+    @mcp.tool(
+        title="Get Transaction",
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    )
+    async def get_transaction(
+        ctx: Context,
+        transaction_id: str = Field(
+            description="Public ID of the transaction to retrieve"
+        ),
+    ) -> Dict[str, Any]:
+        """Get a transaction including its split items and current VAT semantics."""
+        api = ctx.request_context.lifespan_context["api"]
+        company_id = api.company_id
+        if not company_id:
+            return {"error": "No company available. Please authenticate first."}
+        url = urljoin(
+            config.api_base_url,
+            f"api/v1/companies/{company_id}/accounting/transactions/{transaction_id}/",
+        )
+        return await api.arequest("GET", url)
 
     @mcp.tool(
         title="Create Transaction",
@@ -104,17 +190,79 @@ def register_transaction_tools(mcp):
     )
     async def create_transaction(
         ctx: Context,
-        amount: float = Field(description="Transaction amount (positive for income, negative for expense)"),
+        amount: float = Field(
+            description="Transaction amount (positive for income, negative for expense)"
+        ),
         description: str = Field(description="Transaction description"),
-        cashflow_type: str = Field(description="Cashflow type of the transaction (INCOME, EXPENSE)"),
-        supplier_country: str = Field(description="Country of the supplier (DE, INSIDE_EU, OUTSIDE_EU)"),
-        category_id: Optional[str] = Field(default=None, description="Freelance category ID (for non-SME companies). If not provided, auto-categorized via AI."),
-        company_category_id: Optional[str] = Field(default=None, description="SME company category ID from the DATEV chart of accounts (for GmbH/UG companies). Use list_company_categories to find the right ID."),
-        vat_rate: Optional[int] = Field(default=None, description="VAT rate (0, 7, 19)"),
-        sale_type: Optional[str] = Field(default=None, description="Sale type (GOODS, SERVICES)"),
-        date: Optional[str] = Field(default=None, description="Transaction date (document/invoice date) in YYYY-MM-DD format (defaults to today)"),
-        payment_date: Optional[str] = Field(default=None, description="Date when payment was made/received in YYYY-MM-DD format. Used for SME accrual accounting."),
-        payment_type: Optional[str] = Field(default=None, description="Payment method: BANK, CASH, NOT_PAID"),
+        cashflow_type: str = Field(
+            description="Cashflow type of the transaction (INCOME, EXPENSE)"
+        ),
+        supplier_country: str = Field(
+            description="Country of the supplier (DE, INSIDE_EU, OUTSIDE_EU)"
+        ),
+        category_id: Optional[str] = Field(
+            default=None,
+            description="Freelance category ID (for non-SME companies). If not provided, auto-categorized via AI.",
+        ),
+        company_category_id: Optional[str] = Field(
+            default=None,
+            description="SME company category ID from the DATEV chart of accounts (for GmbH/UG companies). Use list_company_categories to find the right ID.",
+        ),
+        vat_rate: Optional[int] = Field(
+            default=None, description="VAT rate (0, 7, 19)"
+        ),
+        currency: Optional[str] = Field(
+            default=None, description="ISO 4217 currency shown on the document"
+        ),
+        sale_type: Optional[str] = Field(
+            default=None, description="Sale type (GOODS, SERVICES)"
+        ),
+        input_vat_type: Optional[str] = Field(
+            default=None,
+            description="VAT shown by an EU/non-EU supplier: NO_VAT, GERMAN_VAT or FOREIGN_VAT",
+        ),
+        reverse_charge: Optional[bool] = Field(
+            default=None, description="Whether reverse charge applies"
+        ),
+        is_refund: bool = Field(
+            default=False, description="Whether this reverses a sale or expense"
+        ),
+        client_id: Optional[str] = Field(
+            default=None,
+            description="Client public ID for income and EU sales/ZM attribution",
+        ),
+        vendor_id: Optional[str] = Field(
+            default=None,
+            description="Vendor public ID for expense and creditor attribution",
+        ),
+        date: Optional[str] = Field(
+            default=None,
+            description="Transaction date (document/invoice date) in YYYY-MM-DD format (defaults to today)",
+        ),
+        payment_date: Optional[str] = Field(
+            default=None,
+            description="Date when payment was made/received in YYYY-MM-DD format. Used for SME accrual accounting.",
+        ),
+        payment_type: Optional[str] = Field(
+            default=None,
+            description="Payment method: BANK, CASH, CREDIT_CARD, PAYPAL or NOT_PAID",
+        ),
+        ledger_payment_account_code: Optional[str] = Field(
+            default=None,
+            description="Optional cash/bank/card/PayPal Ledger account override for the payment side",
+        ),
+        category_metadata: Optional[dict] = Field(
+            default=None,
+            description="Optional category-specific metadata used by Norman tax and deduction treatments",
+        ),
+        items: Optional[List[dict]] = Field(
+            default=None,
+            description=(
+                "Complete split lines for documents with multiple categories or VAT rates. "
+                "Each line: {description, amount (positive gross), vat_rate, vat_type?, "
+                "category_id? or company_category_id?}; lines must sum to the transaction total."
+            ),
+        ),
     ) -> Dict[str, Any]:
         """
         Create a new manual transaction.
@@ -124,18 +272,18 @@ def register_transaction_tools(mcp):
         """
         api = ctx.request_context.lifespan_context["api"]
         company_id = api.company_id
-        
+
         if cashflow_type not in ["INCOME", "EXPENSE"]:
             return {"error": "cashflow_type must be either 'INCOME' or 'EXPENSE'"}
-        
+
         if not date:
             date = datetime.now().strftime("%Y-%m-%d")
-        
+
         transactions_url = urljoin(
-            config.api_base_url, 
-            f"api/v1/companies/{company_id}/accounting/transactions/"
+            config.api_base_url,
+            f"api/v1/companies/{company_id}/accounting/transactions/",
         )
-        
+
         transaction_data = {
             "amount": abs(amount) if cashflow_type == "INCOME" else -abs(amount),
             "description": description,
@@ -144,9 +292,10 @@ def register_transaction_tools(mcp):
             "vatRate": vat_rate,
             "saleType": sale_type if sale_type else "",
             "supplierCountry": supplier_country,
-            "company": company_id
+            "isRefund": is_refund,
+            "company": company_id,
         }
-        
+
         if category_id:
             transaction_data["category_id"] = category_id
         if company_category_id:
@@ -155,8 +304,34 @@ def register_transaction_tools(mcp):
             transaction_data["paymentDate"] = payment_date
         if payment_type:
             transaction_data["paymentType"] = payment_type
-        
-        return api._make_request("POST", transactions_url, json_data=transaction_data)
+        if input_vat_type is not None:
+            transaction_data["inputVatType"] = input_vat_type
+        if reverse_charge is not None:
+            transaction_data["reverseCharge"] = reverse_charge
+        if client_id:
+            transaction_data["client"] = client_id
+        if vendor_id:
+            transaction_data["vendor"] = vendor_id
+        if ledger_payment_account_code:
+            transaction_data["ledgerPaymentAccountCode"] = ledger_payment_account_code
+        if category_metadata:
+            transaction_data["categoryMetadata"] = category_metadata
+        if currency:
+            transaction_data["currency"] = currency
+        if items:
+            mismatch = _items_total_mismatch(items, amount)
+            if mismatch:
+                return mismatch
+            transaction_data["items"] = _build_items_payload(
+                items,
+                negate=cashflow_type == "EXPENSE",
+            )
+            transaction_data.pop("amount", None)
+            transaction_data.pop("vatRate", None)
+            transaction_data.pop("category_id", None)
+            transaction_data.pop("companyCategory", None)
+
+        return await api.arequest("POST", transactions_url, json_data=transaction_data)
 
     @mcp.tool(
         title="Update Transaction",
@@ -169,59 +344,206 @@ def register_transaction_tools(mcp):
     )
     async def update_transaction(
         ctx: Context,
-        transaction_id: str = Field(description="Public ID of the transaction to update"),
-        amount: Optional[float] = Field(default=None, description="Transaction amount (positive for income, negative for expense)"),
-        description: Optional[str] = Field(default=None, description="Transaction description"),
-        category: Optional[str] = Field(default=None, description="Freelance category name or ID"),
-        date: Optional[str] = Field(default=None, description="Transaction date (document/invoice date) in YYYY-MM-DD format"),
-        vat_rate: Optional[int] = Field(default=None, description="VAT rate (0, 7, 19)"),
-        sale_type: Optional[str] = Field(default=None, description="Sale type (GOODS, SERVICES)"),
-        supplier_country: Optional[str] = Field(default=None, description="Country of the supplier (DE, INSIDE_EU, OUTSIDE_EU)"),
-        cashflow_type: Optional[str] = Field(default=None, description="Cashflow type of the transaction (INCOME, EXPENSE)"),
-        category_id: Optional[str] = Field(default=None, description="Freelance category ID"),
-        company_category_id: Optional[str] = Field(default=None, description="SME company category ID from DATEV chart of accounts (for GmbH/UG)"),
-        payment_date: Optional[str] = Field(default=None, description="Date when payment was made/received in YYYY-MM-DD format"),
-        payment_type: Optional[str] = Field(default=None, description="Payment method: BANK, CASH, NOT_PAID"),
+        transaction_id: str = Field(
+            description="Public ID of the transaction to update"
+        ),
+        amount: Optional[float] = Field(
+            default=None,
+            description="Transaction amount (positive for income, negative for expense)",
+        ),
+        description: Optional[str] = Field(
+            default=None, description="Transaction description"
+        ),
+        category: Optional[str] = Field(
+            default=None, description="Freelance category name or ID"
+        ),
+        date: Optional[str] = Field(
+            default=None,
+            description="Transaction date (document/invoice date) in YYYY-MM-DD format",
+        ),
+        vat_rate: Optional[int] = Field(
+            default=None, description="VAT rate (0, 7, 19)"
+        ),
+        currency: Optional[str] = Field(
+            default=None, description="ISO 4217 currency shown on the document"
+        ),
+        sale_type: Optional[str] = Field(
+            default=None, description="Sale type (GOODS, SERVICES)"
+        ),
+        input_vat_type: Optional[str] = Field(
+            default=None, description="NO_VAT, GERMAN_VAT or FOREIGN_VAT"
+        ),
+        reverse_charge: Optional[bool] = Field(
+            default=None, description="Whether reverse charge applies"
+        ),
+        is_refund: Optional[bool] = Field(
+            default=None, description="Whether this is a refund/reversal transaction"
+        ),
+        client_id: Optional[str] = Field(
+            default=None, description="Client public ID, or empty string to clear"
+        ),
+        vendor_id: Optional[str] = Field(
+            default=None, description="Vendor public ID, or empty string to clear"
+        ),
+        supplier_country: Optional[str] = Field(
+            default=None,
+            description="Country of the supplier (DE, INSIDE_EU, OUTSIDE_EU)",
+        ),
+        cashflow_type: Optional[str] = Field(
+            default=None,
+            description="Cashflow type of the transaction (INCOME, EXPENSE)",
+        ),
+        category_id: Optional[str] = Field(
+            default=None, description="Freelance category ID"
+        ),
+        company_category_id: Optional[str] = Field(
+            default=None,
+            description="SME company category ID from DATEV chart of accounts (for GmbH/UG)",
+        ),
+        payment_date: Optional[str] = Field(
+            default=None,
+            description="Date when payment was made/received in YYYY-MM-DD format",
+        ),
+        payment_type: Optional[str] = Field(
+            default=None,
+            description="Payment method: BANK, CASH, CREDIT_CARD, PAYPAL or NOT_PAID",
+        ),
+        ledger_payment_account_code: Optional[str] = Field(
+            default=None, description="Payment-side Ledger account override"
+        ),
+        category_metadata: Optional[dict] = Field(
+            default=None, description="Category-specific tax/deduction metadata"
+        ),
+        document_not_required: Optional[bool] = Field(
+            default=None, description="Whether no receipt/invoice is required"
+        ),
+        advisor_notes: Optional[str] = Field(
+            default=None, description="Private internal accounting note"
+        ),
+        items: Optional[List[dict]] = Field(
+            default=None,
+            description=(
+                "Replace all split items with this COMPLETE list. Each line contains a positive "
+                "gross amount, VAT rate and category; lines must sum to the transaction total."
+            ),
+        ),
     ) -> Dict[str, Any]:
         """Update an existing transaction. For SME companies, use company_category_id and payment fields."""
         api = ctx.request_context.lifespan_context["api"]
         company_id = api.company_id
-        
+
         if not company_id:
             return {"error": "No company available. Please authenticate first."}
-        
+
         transaction_url = urljoin(
-            config.api_base_url, 
-            f"api/v1/companies/{company_id}/accounting/transactions/{transaction_id}/"
+            config.api_base_url,
+            f"api/v1/companies/{company_id}/accounting/transactions/{transaction_id}/",
         )
-        
+
         update_data = {}
-        if amount is not None:
-            update_data["amount"] = abs(amount) if cashflow_type == "INCOME" else -abs(amount)
+        existing = None
+        if items or (amount is not None and cashflow_type is None):
+            existing = await api.arequest("GET", transaction_url)
+        if items:
+            existing_amount = (existing or {}).get("amount")
+            try:
+                is_expense = float(existing_amount) < 0
+            except (TypeError, ValueError):
+                is_expense = (existing or {}).get("cashflowType") == "EXPENSE"
+            reference_total = amount if amount is not None else existing_amount
+            if reference_total is not None:
+                try:
+                    mismatch = _items_total_mismatch(items, float(reference_total))
+                except (TypeError, ValueError):
+                    mismatch = None
+                if mismatch:
+                    return mismatch
+            update_data["items"] = _build_items_payload(items, negate=is_expense)
+        if amount is not None and not items:
+            effective_cashflow_type = cashflow_type or (existing or {}).get(
+                "cashflowType"
+            )
+            update_data["amount"] = (
+                abs(amount) if effective_cashflow_type == "INCOME" else -abs(amount)
+            )
         if description is not None:
             update_data["description"] = description
-        if category is not None:
+        if category is not None and not items:
             update_data["category"] = category
         if date is not None:
             update_data["valueDate"] = date
-        if vat_rate is not None:
+        if vat_rate is not None and not items:
             update_data["vatRate"] = vat_rate
         if sale_type is not None:
             update_data["saleType"] = sale_type if sale_type else ""
         if supplier_country is not None:
             update_data["supplierCountry"] = supplier_country
+        if input_vat_type is not None:
+            update_data["inputVatType"] = input_vat_type
+        if reverse_charge is not None:
+            update_data["reverseCharge"] = reverse_charge
+        if is_refund is not None:
+            update_data["isRefund"] = is_refund
+        if client_id is not None:
+            update_data["client"] = client_id or None
+        if vendor_id is not None:
+            update_data["vendor"] = vendor_id or None
         if cashflow_type is not None:
             update_data["cashflowType"] = cashflow_type
-        if category_id is not None:
+        if category_id is not None and not items:
             update_data["category"] = category_id
-        if company_category_id is not None:
+        if company_category_id is not None and not items:
             update_data["companyCategory"] = company_category_id
         if payment_date is not None:
             update_data["paymentDate"] = payment_date
         if payment_type is not None:
             update_data["paymentType"] = payment_type
-            
-        return api._make_request("PATCH", transaction_url, json_data=update_data)
+        if ledger_payment_account_code is not None:
+            update_data["ledgerPaymentAccountCode"] = ledger_payment_account_code
+        if category_metadata is not None:
+            update_data["categoryMetadata"] = category_metadata
+        if document_not_required is not None:
+            update_data["documentNotRequired"] = document_not_required
+        if advisor_notes is not None:
+            update_data["advisorNotes"] = advisor_notes
+        if currency is not None:
+            update_data["currency"] = currency
+
+        return await api.arequest("PATCH", transaction_url, json_data=update_data)
+
+    @mcp.tool(
+        title="Delete Transaction",
+        annotations=ToolAnnotations(
+            readOnlyHint=False,
+            destructiveHint=True,
+            idempotentHint=False,
+            openWorldHint=False,
+        ),
+    )
+    async def delete_transaction(
+        ctx: Context,
+        transaction_id: str = Field(
+            description="Public ID of the transaction to delete"
+        ),
+        confirmed: bool = Field(
+            default=False, description="Must be true after explicit user confirmation"
+        ),
+    ) -> Dict[str, Any]:
+        """Delete a transaction and its regenerable Ledger postings after confirmation."""
+        if not confirmed:
+            return {
+                "confirmationRequired": True,
+                "warning": "This deletes the transaction and its synthesized Ledger postings.",
+            }
+        api = ctx.request_context.lifespan_context["api"]
+        company_id = api.company_id
+        if not company_id:
+            return {"error": "No company available. Please authenticate first."}
+        url = urljoin(
+            config.api_base_url,
+            f"api/v1/companies/{company_id}/accounting/transactions/{transaction_id}/",
+        )
+        return await api.arequest("DELETE", url)
 
     @mcp.tool(
         title="Categorize Transaction",
@@ -235,34 +557,35 @@ def register_transaction_tools(mcp):
     async def categorize_transaction(
         ctx: Context,
         transaction_amount: float = Field(description="Amount of the transaction"),
-        transaction_description: str = Field(description="Description of the transaction"),
-        transaction_type: str = Field(description="Type of transaction (income or expense)")
+        transaction_description: str = Field(
+            description="Description of the transaction"
+        ),
+        transaction_type: str = Field(
+            description="Type of transaction (income or expense)"
+        ),
     ) -> Dict[str, Any]:
         """
         Detect category for a transaction using AI.
-        
+
         Args:
             transaction_amount: Amount of the transaction
             transaction_description: Description of the transaction
             transaction_type: Type of transaction ("income" or "expense")
-            
+
         Returns:
             Suggested category information for the transaction
         """
         api = ctx.request_context.lifespan_context["api"]
-        
-        detect_url = urljoin(
-            config.api_base_url,
-            "api/v1/assistant/detect-category/"
-        )
-        
+
+        detect_url = urljoin(config.api_base_url, "api/v1/assistant/detect-category/")
+
         request_data = {
             "transaction_amount": transaction_amount,
             "transaction_description": transaction_description,
-            "transaction_type": transaction_type
+            "transaction_type": transaction_type,
         }
-        
-        return api._make_request("POST", detect_url, json_data=request_data)
+
+        return await api.arequest("POST", detect_url, json_data=request_data)
 
     @mcp.tool(
         title="Change Transaction Verification Status",
@@ -275,31 +598,35 @@ def register_transaction_tools(mcp):
     )
     async def change_transaction_verification(
         ctx: Context,
-        transaction_id: str = Field(description="Public ID of the transaction to update"),
-        verify: bool = Field(description="If True, verify (finalize) the transaction; if False, unverify (unfinalize) it")
+        transaction_id: str = Field(
+            description="Public ID of the transaction to update"
+        ),
+        verify: bool = Field(
+            description="If True, verify (finalize) the transaction; if False, unverify (unfinalize) it"
+        ),
     ) -> Dict[str, Any]:
         """
         Verify or unverify a transaction (finalize or unfinalize).
-        
+
         Args:
             transaction_id: Public ID of the transaction to update
             verify: If True, verify (finalize) the transaction; if False, unverify (unfinalize) it
-            
+
         Returns:
             Updated transaction information
         """
         api = ctx.request_context.lifespan_context["api"]
         company_id = api.company_id
-        
+
         if not company_id:
             return {"error": "No company available. Please authenticate first."}
-        
+
         # Choose the appropriate endpoint based on the verify parameter
         action = "verify" if verify else "unverify"
-        
+
         transaction_url = urljoin(
             config.api_base_url,
-            f"api/v1/companies/{company_id}/accounting/transactions/{transaction_id}/{action}/"
+            f"api/v1/companies/{company_id}/accounting/transactions/{transaction_id}/{action}/",
         )
-        
-        return api._make_request("POST", transaction_url) 
+
+        return await api.arequest("POST", transaction_url)

--- a/tests/test_accounting_tools.py
+++ b/tests/test_accounting_tools.py
@@ -1,0 +1,175 @@
+import asyncio
+import inspect
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any
+
+from norman_mcp.tools.accounting import register_accounting_tools
+
+
+class FakeMcp:
+    def __init__(self) -> None:
+        self.tools: dict[str, Callable[..., Any]] = {}
+
+    def tool(
+        self, *args: Any, **kwargs: Any
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        del args, kwargs
+
+        def register(function: Callable[..., Any]) -> Callable[..., Any]:
+            self.tools[function.__name__] = function
+            return function
+
+        return register
+
+
+class FakeApi:
+    company_id = "company-1"
+
+    def __init__(self) -> None:
+        self.requests: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def arequest(self, method: str, url: str, **kwargs: Any) -> dict[str, Any]:
+        self.requests.append((method, url, kwargs))
+        return {"ok": True}
+
+
+def context_for(api: FakeApi) -> SimpleNamespace:
+    return SimpleNamespace(
+        request_context=SimpleNamespace(lifespan_context={"api": api})
+    )
+
+
+def registered_tools() -> tuple[FakeMcp, FakeApi]:
+    mcp = FakeMcp()
+    api = FakeApi()
+    register_accounting_tools(mcp)
+    return mcp, api
+
+
+def test_accounting_workspace_registers_safe_parity_without_binding_submission() -> (
+    None
+):
+    mcp, _api = registered_tools()
+
+    assert {
+        "list_chart_of_accounts",
+        "create_chart_of_accounts_account",
+        "list_assets",
+        "list_ledger_journal",
+        "get_ledger_profit_and_loss",
+        "get_ledger_balance_sheet",
+        "create_manual_ledger_entry",
+        "list_annual_closes",
+        "create_annual_close",
+        "get_annual_close",
+        "create_annual_close_entry",
+        "get_annual_close_workbook",
+    }.issubset(mcp.tools)
+    assert not {name for name in mcp.tools if "submit" in name or "lock" in name}
+
+
+def test_annual_close_creation_is_draft_only() -> None:
+    mcp, api = registered_tools()
+
+    asyncio.run(
+        mcp.tools["create_annual_close"](
+            context_for(api),
+            fiscal_year_begin="2026-01-01",
+            fiscal_year_end="2026-12-31",
+        ),
+    )
+
+    method, url, kwargs = api.requests[-1]
+    assert method == "POST"
+    assert url.endswith("/api/v1/companies/company-1/accounting/annual-closes/")
+    assert kwargs["json_data"] == {
+        "fiscalYearBegin": "2026-01-01",
+        "fiscalYearEnd": "2026-12-31",
+    }
+
+
+def test_ledger_journal_declares_newest_first_as_its_default() -> None:
+    mcp, _api = registered_tools()
+
+    ordering = (
+        inspect.signature(mcp.tools["list_ledger_journal"])
+        .parameters["ordering"]
+        .default
+    )
+
+    assert ordering.default == "date_desc"
+
+
+def test_framework_switch_requires_confirmation_and_forwards_ui_guard() -> None:
+    mcp, api = registered_tools()
+    context = context_for(api)
+
+    warning = asyncio.run(
+        mcp.tools["switch_account_framework"](
+            context,
+            framework_code="skr04",
+            confirmed=False,
+        ),
+    )
+    result = asyncio.run(
+        mcp.tools["switch_account_framework"](
+            context,
+            framework_code="skr04",
+            confirmed=True,
+        ),
+    )
+
+    assert warning["confirmationRequired"] is True
+    assert result == {"ok": True}
+    assert len(api.requests) == 1
+    method, url, kwargs = api.requests[0]
+    assert method == "PATCH"
+    assert url.endswith("/api/v1/companies/company-1/")
+    assert kwargs["json_data"] == {
+        "chartOfAccounts": "skr04",
+        "confirmChartOfAccountsSwitch": True,
+    }
+
+
+def test_asset_business_use_percent_is_converted_to_model_fraction() -> None:
+    mcp, api = registered_tools()
+
+    asyncio.run(
+        mcp.tools["create_asset"](
+            context_for(api),
+            name="Mac Studio",
+            asset_type="tangible",
+            acquisition_date="2026-08-28",
+            depreciation_basis=1000,
+            useful_lifetime_months=36,
+            gross_purchase_price=1190,
+            business_use_percent=80,
+            ledger_account_code="0670",
+            transaction_id=None,
+            transaction_item_id=None,
+        ),
+    )
+
+    method, url, kwargs = api.requests[-1]
+    assert method == "POST"
+    assert url.endswith("/api/v1/companies/company-1/accounting/assets/")
+    assert kwargs["json_data"]["useProfessionalPart"] == 0.8
+
+
+def test_storno_requires_confirmation() -> None:
+    mcp, api = registered_tools()
+    context = context_for(api)
+
+    warning = asyncio.run(
+        mcp.tools["reverse_manual_ledger_entry"](
+            context,
+            entry_id="entry-1",
+            confirmed=False,
+            booking_date=None,
+            memo="",
+        ),
+    )
+
+    assert warning["confirmationRequired"] is True
+    assert api.requests == []

--- a/tests/test_api_client_async.py
+++ b/tests/test_api_client_async.py
@@ -1,0 +1,34 @@
+import asyncio
+
+from norman_mcp.api.client import NormanAPI
+
+
+def test_arequest_runs_the_existing_secured_request_path(monkeypatch) -> None:
+    api = NormanAPI(authenticate_on_init=False)
+    calls = []
+
+    def fake_request(method, url, params=None, json_data=None, files=None):
+        calls.append((method, url, params, json_data, files))
+        return {"ok": True}
+
+    monkeypatch.setattr(api, "_make_request", fake_request)
+
+    result = asyncio.run(
+        api.arequest(
+            "POST",
+            "https://api.norman.finance/api/v1/example/",
+            params={"page": 1},
+            json_data={"name": "test"},
+        ),
+    )
+
+    assert result == {"ok": True}
+    assert calls == [
+        (
+            "POST",
+            "https://api.norman.finance/api/v1/example/",
+            {"page": 1},
+            {"name": "test"},
+            None,
+        ),
+    ]

--- a/tests/test_transaction_items_payload.py
+++ b/tests/test_transaction_items_payload.py
@@ -1,0 +1,31 @@
+"""Split-transaction shaping shared with the embedded Norman MCP."""
+
+from norman_mcp.tools.transactions import _build_items_payload, _items_total_mismatch
+
+
+def test_expense_items_are_negated_and_ordered() -> None:
+    payload = _build_items_payload(
+        [
+            {"description": "Food", "amount": 47.2, "vat_rate": 7},
+            {
+                "description": "Household",
+                "amount": 19.5,
+                "vat_rate": 19,
+                "company_category_id": "coa-1",
+            },
+        ],
+        negate=True,
+    )
+
+    assert payload[0]["amount"] == -47.2
+    assert payload[0]["order"] == 0
+    assert payload[1]["amount"] == -19.5
+    assert payload[1]["companyCategory"] == "coa-1"
+
+
+def test_mismatched_totals_are_rejected() -> None:
+    mismatch = _items_total_mismatch([{"amount": 47.2}, {"amount": 10}], 66.7)
+
+    assert mismatch is not None
+    assert "57.20" in mismatch["error"]
+    assert "66.70" in mismatch["error"]


### PR DESCRIPTION
## Summary
- add MCP parity for the SME company accounting workspace: Setup, chart of accounts, Assets, Ledger views, statements and draft annual close
- expose safe create/update/deactivate/reversal workflows with explicit confirmation for destructive changes
- extend transaction tools with split items, VAT/tax treatment, payment account routing, client/vendor links and confirmed deletion
- use the existing authenticated API client through a request-scoped async adapter

## Safety boundary
- does not expose binding tax submission, annual-close locking, or cutover apply
- keeps framework switching, asset deletion, transaction deletion and Storno behind explicit confirmation
- binary DATEV/GoBD/preview artifacts remain outside this JSON tool surface until MCP artifact/resource transport is added

## Validation
- `68 passed, 3 skipped` excluding the pre-existing `tests/test_basic.py` import failure
- FastMCP registration smoke: 147 tools, all new accounting tools present
- accounting parity AST check: 27 tools, no difference versus embedded MCP
- compileall and scoped Ruff checks passed