### PR TITLE
feat(accounting): add opening and cutover MCP workflow

### DIFF
--- a/norman_mcp/api/client.py
+++ b/norman_mcp/api/client.py
@@ -377,7 +377,7 @@ class NormanAPI:
         url: str,
         params: Optional[Dict[str, Any]] = None,
         json_data: Optional[Dict[str, Any]] = None,
-        files: Optional[Dict[str, Any]] = None,
+        files: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """Make a request to the Norman Finance API with security controls."""
         # Resolve the caller's token for THIS request. Keep it in a local: it
@@ -584,7 +584,7 @@ class NormanAPI:
         url: str,
         params: Optional[Dict[str, Any]] = None,
         json_data: Optional[Dict[str, Any]] = None,
-        files: Optional[Dict[str, Any]] = None,
+        files: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """Run the blocking requests client off the MCP event loop."""
         return await asyncio.to_thread(

--- a/norman_mcp/tools/accounting.py
+++ b/norman_mcp/tools/accounting.py
@@ -7,6 +7,10 @@ Ledger remains the source of truth and the API remains the only writer.
 
 from __future__ import annotations
 
+import json
+import mimetypes
+from contextlib import ExitStack
+from pathlib import Path
 from typing import Any, Dict, Optional
 from urllib.parse import urljoin
 
@@ -16,6 +20,7 @@ from pydantic import Field
 from norman_mcp import config
 from norman_mcp.context import Context
 
+from norman_mcp.files.upload import resolve_ref
 
 READ_ONLY = ToolAnnotations(
     readOnlyHint=True,
@@ -60,9 +65,16 @@ async def _request(
     *,
     params: Optional[Dict[str, Any]] = None,
     json_data: Optional[Dict[str, Any]] = None,
+    files: Optional[Any] = None,
 ) -> Dict[str, Any]:
     """Use the non-blocking client in both the embedded and standalone MCP."""
-    return await api.arequest(method, url, params=params, json_data=json_data)
+    return await api.arequest(
+        method,
+        url,
+        params=params,
+        json_data=json_data,
+        files=files,
+    )
 
 
 def _company_url(company_id: str, suffix: str) -> str:
@@ -73,6 +85,92 @@ def _company_url(company_id: str, suffix: str) -> str:
 
 def _compact(data: Dict[str, Any]) -> Dict[str, Any]:
     return {key: value for key, value in data.items() if value is not None}
+
+
+def _cutover_payload(
+    *,
+    mode: str,
+    fiscal_year_begin: str,
+    fiscal_year_end: str,
+    cutover_date: str,
+    opening_method: str,
+    manual_balance_date: Optional[str],
+    manual_balances: Optional[list[Dict[str, Any]]],
+) -> Dict[str, Any]:
+    return _compact(
+        {
+            "mode": mode,
+            "opening_method": opening_method,
+            "fiscal_year_begin": fiscal_year_begin,
+            "fiscal_year_end": fiscal_year_end,
+            "cutover_date": cutover_date,
+            "manual_balance_date": manual_balance_date,
+            "manual_balances": manual_balances,
+        }
+    )
+
+
+def _cutover_file_fields(
+    *,
+    opening_file_ref: Optional[str],
+    booking_file_refs: Optional[list[str]],
+    parties_file_ref: Optional[str],
+    assets_file_ref: Optional[str],
+) -> list[tuple[str, str]]:
+    fields: list[tuple[str, str]] = []
+    if opening_file_ref:
+        fields.append(("opening_file", opening_file_ref))
+    fields.extend(("bookings_files", ref) for ref in booking_file_refs or [])
+    if parties_file_ref:
+        fields.append(("parties_file", parties_file_ref))
+    if assets_file_ref:
+        fields.append(("assets_file", assets_file_ref))
+    return fields
+
+
+def _original_upload_name(file_ref: str, path: Path) -> str:
+    prefix = f"{file_ref}_"
+    return path.name[len(prefix) :] if path.name.startswith(prefix) else path.name
+
+
+async def _post_cutover(
+    api: Any,
+    url: str,
+    *,
+    payload: Dict[str, Any],
+    file_fields: list[tuple[str, str]],
+) -> Dict[str, Any]:
+    """Resolve short-lived uploads and post a cutover multipart request safely."""
+    resolved: list[tuple[str, str, Path]] = []
+    for field_name, file_ref in file_fields:
+        path = resolve_ref(file_ref)
+        if path is None:
+            return {
+                "error": (
+                    f"file_ref '{file_ref}' was not found or has expired. "
+                    "Upload the file again and retry."
+                )
+            }
+        resolved.append((field_name, file_ref, Path(path)))
+
+    request_payload = dict(payload)
+    if resolved and isinstance(request_payload.get("manual_balances"), list):
+        request_payload["manual_balances"] = json.dumps(request_payload["manual_balances"])
+
+    with ExitStack() as stack:
+        files: list[tuple[str, tuple[str, Any, str]]] = []
+        for field_name, file_ref, path in resolved:
+            filename = _original_upload_name(file_ref, path)
+            content_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+            handle = stack.enter_context(path.open("rb"))
+            files.append((field_name, (filename, handle, content_type)))
+        return await _request(
+            api,
+            "POST",
+            url,
+            json_data=request_payload,
+            files=files or None,
+        )
 
 
 def register_accounting_tools(mcp: Any) -> None:
@@ -101,6 +199,162 @@ def register_accounting_tools(mcp: Any) -> None:
                 "fiscalYearBegin": fiscal_year_begin,
                 "fiscalYearEnd": fiscal_year_end,
             },
+        )
+
+    @mcp.tool(title="Analyze Accounting Migration Files", annotations=READ_ONLY)
+    async def analyze_accounting_cutover_documents(
+        ctx: Context,
+        file_refs: list[str] = Field(
+            description=(
+                "One to 20 uploaded DATEV, CSV or supporting document references. "
+                "Analysis detects file roles, fiscal periods and the likely SKR framework."
+            )
+        ),
+    ) -> Dict[str, Any]:
+        """Analyze migration files without writing anything to the Ledger."""
+        if not 1 <= len(file_refs) <= 20:
+            return {"error": "Provide between 1 and 20 file_ref values."}
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        return await _post_cutover(
+            api,
+            _company_url(company_id, "accounting/cutover/analyze/"),
+            payload={},
+            file_fields=[("files", file_ref) for file_ref in file_refs],
+        )
+
+    @mcp.tool(title="Preview Accounting Migration", annotations=READ_ONLY)
+    async def preview_accounting_cutover(
+        ctx: Context,
+        mode: str = Field(description="formation, year_start or mid_year"),
+        fiscal_year_begin: str = Field(description="YYYY-MM-DD"),
+        fiscal_year_end: str = Field(description="YYYY-MM-DD"),
+        cutover_date: str = Field(
+            description="Last date covered by the imported books, in YYYY-MM-DD format"
+        ),
+        opening_method: str = Field(default="datev", description="datev or manual"),
+        opening_file_ref: Optional[str] = Field(
+            default=None, description="Uploaded DATEV opening-balance file reference"
+        ),
+        booking_file_refs: Optional[list[str]] = Field(
+            default=None,
+            description="Uploaded DATEV booking-stack references, in period order",
+        ),
+        parties_file_ref: Optional[str] = Field(
+            default=None, description="Optional uploaded customer/vendor file reference"
+        ),
+        assets_file_ref: Optional[str] = Field(
+            default=None, description="Optional uploaded asset-register file reference"
+        ),
+        manual_balance_date: Optional[str] = Field(
+            default=None,
+            description="Balance date for manual opening balances, in YYYY-MM-DD format",
+        ),
+        manual_balances: Optional[list[Dict[str, Any]]] = Field(
+            default=None,
+            description=(
+                "Manual opening rows with account_code, side (debit or credit), "
+                "amount and optional memo"
+            ),
+        ),
+    ) -> Dict[str, Any]:
+        """Preview findings and reconciliation without changing the books."""
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        return await _post_cutover(
+            api,
+            _company_url(company_id, "accounting/cutover/preview/"),
+            payload=_cutover_payload(
+                mode=mode,
+                fiscal_year_begin=fiscal_year_begin,
+                fiscal_year_end=fiscal_year_end,
+                cutover_date=cutover_date,
+                opening_method=opening_method,
+                manual_balance_date=manual_balance_date,
+                manual_balances=manual_balances,
+            ),
+            file_fields=_cutover_file_fields(
+                opening_file_ref=opening_file_ref,
+                booking_file_refs=booking_file_refs,
+                parties_file_ref=parties_file_ref,
+                assets_file_ref=assets_file_ref,
+            ),
+        )
+
+    @mcp.tool(title="Apply Accounting Migration", annotations=DESTRUCTIVE)
+    async def apply_accounting_cutover(
+        ctx: Context,
+        mode: str = Field(description="formation, year_start or mid_year"),
+        fiscal_year_begin: str = Field(description="YYYY-MM-DD"),
+        fiscal_year_end: str = Field(description="YYYY-MM-DD"),
+        cutover_date: str = Field(
+            description="Last date covered by the imported books, in YYYY-MM-DD format"
+        ),
+        confirmed: bool = Field(
+            default=False,
+            description=(
+                "Must be true only after the user reviewed a preview made with the exact same inputs"
+            ),
+        ),
+        opening_method: str = Field(default="datev", description="datev or manual"),
+        opening_file_ref: Optional[str] = Field(
+            default=None, description="Uploaded DATEV opening-balance file reference"
+        ),
+        booking_file_refs: Optional[list[str]] = Field(
+            default=None,
+            description="Uploaded DATEV booking-stack references, in period order",
+        ),
+        parties_file_ref: Optional[str] = Field(
+            default=None, description="Optional uploaded customer/vendor file reference"
+        ),
+        assets_file_ref: Optional[str] = Field(
+            default=None, description="Optional uploaded asset-register file reference"
+        ),
+        manual_balance_date: Optional[str] = Field(
+            default=None,
+            description="Balance date for manual opening balances, in YYYY-MM-DD format",
+        ),
+        manual_balances: Optional[list[Dict[str, Any]]] = Field(
+            default=None,
+            description=(
+                "Manual opening rows with account_code, side (debit or credit), "
+                "amount and optional memo"
+            ),
+        ),
+    ) -> Dict[str, Any]:
+        """Write previewed opening/cutover data only after explicit confirmation."""
+        if not confirmed:
+            return {
+                "confirmationRequired": True,
+                "warning": (
+                    "Applying the migration writes opening and cutover postings to the Ledger "
+                    "and establishes the transaction cutover boundary. Review a successful "
+                    "preview made with these exact inputs before confirming."
+                ),
+            }
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return error
+        return await _post_cutover(
+            api,
+            _company_url(company_id, "accounting/cutover/import/"),
+            payload=_cutover_payload(
+                mode=mode,
+                fiscal_year_begin=fiscal_year_begin,
+                fiscal_year_end=fiscal_year_end,
+                cutover_date=cutover_date,
+                opening_method=opening_method,
+                manual_balance_date=manual_balance_date,
+                manual_balances=manual_balances,
+            ),
+            file_fields=_cutover_file_fields(
+                opening_file_ref=opening_file_ref,
+                booking_file_refs=booking_file_refs,
+                parties_file_ref=parties_file_ref,
+                assets_file_ref=assets_file_ref,
+            ),
         )
 
     @mcp.tool(title="List Chart of Accounts Templates", annotations=READ_ONLY)

--- a/skills/accounting-cutover/SKILL.md
+++ b/skills/accounting-cutover/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: accounting-cutover
+description: Analyze and migrate opening balances or prior DATEV books into Norman's SME Ledger. Use when a GmbH or UG is starting its books, changing accounting systems, importing DATEV opening balances, or performing an accounting cutover.
+metadata:
+  openclaw:
+    emoji: "\U0001F4DA"
+    homepage: https://norman.finance
+    requires:
+      mcp:
+        - norman-finance
+---
+
+Guide a company through an accounting migration without changing its Ledger until the user has reviewed the preview and explicitly confirmed the import.
+
+## 1. Inspect the current setup
+
+- Call `get_accounting_setup` for the relevant fiscal year.
+- Note the current SKR framework, existing cutover state and any previously imported entries.
+- Do not switch SKR03 or SKR04 automatically. A framework switch has broader accounting consequences and requires its own explicit confirmation.
+
+## 2. Collect and analyze source files
+
+- Upload the available DATEV files or supporting documents and retain their short-lived `file_ref` values.
+- Call `analyze_accounting_cutover_documents` with all related files together.
+- Present the detected file roles, fiscal periods, likely SKR framework and any ambiguity to the user.
+- Ask for a replacement file when a reference has expired.
+
+File limits enforced by the Accounting API:
+
+- 1 to 20 files per analysis
+- 20 MB per file and 100 MB in total
+- PDFs may be analyzed as supporting evidence, but opening-balance and booking-stack inputs for Preview and Apply must be machine-readable DATEV or CSV files
+
+## 3. Choose the migration scenario
+
+- `formation`: a newly formed GmbH or UG with legal opening entries
+- `year_start`: prior-year closing balances become this year's opening balances
+- `mid_year`: opening balances plus all bookings through the cutover date
+
+Choose `opening_method=datev` when an opening-balance file exists. Choose `opening_method=manual` only when the user wants to enter non-zero account balances directly. Manual rows require `account_code`, `side` (`debit` or `credit`), `amount`, and may include `memo`.
+
+## 4. Preview before writing
+
+- Call `preview_accounting_cutover` with the complete set of dates, files and manual rows.
+- Explain reconciliation totals, detected periods, blockers and warnings in plain language.
+- Treat Preview as read-only. It does not write Ledger entries.
+- Resolve every blocking finding before proceeding.
+
+## 5. Apply only after explicit confirmation
+
+- Ask the user to confirm the exact successful Preview.
+- Call `apply_accounting_cutover` with the same inputs and `confirmed=true` only after that confirmation.
+- If any date, file, balance row or migration mode changes, run Preview again before Apply.
+- Apply writes opening/cutover postings and establishes the boundary before which transaction-derived postings must not be duplicated.
+
+## 6. Verify the result
+
+- Call `get_accounting_setup` again and inspect the returned import status and counts.
+- Use the Ledger tools to verify the affected accounts and dates.
+- Report any remaining warnings without attempting tax submission or annual-close locking.

--- a/tests/test_accounting_tools.py
+++ b/tests/test_accounting_tools.py
@@ -1,9 +1,11 @@
 import asyncio
 import inspect
+import json
 from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any
 
+from norman_mcp.files.upload import store_file
 from norman_mcp.tools.accounting import register_accounting_tools
 
 
@@ -53,6 +55,9 @@ def test_accounting_workspace_registers_safe_parity_without_binding_submission()
     mcp, _api = registered_tools()
 
     assert {
+        "analyze_accounting_cutover_documents",
+        "preview_accounting_cutover",
+        "apply_accounting_cutover",
         "list_chart_of_accounts",
         "create_chart_of_accounts_account",
         "list_assets",
@@ -67,6 +72,157 @@ def test_accounting_workspace_registers_safe_parity_without_binding_submission()
         "get_annual_close_workbook",
     }.issubset(mcp.tools)
     assert not {name for name in mcp.tools if "submit" in name or "lock" in name}
+
+
+def test_cutover_analysis_sends_repeated_multipart_file_fields() -> None:
+    mcp, api = registered_tools()
+    first_ref = store_file(b"first", "DTVF_Buchungsstapel_1.csv")
+    second_ref = store_file(b"second", "DTVF_Buchungsstapel_2.csv")
+
+    result = asyncio.run(
+        mcp.tools["analyze_accounting_cutover_documents"](
+            context_for(api),
+            file_refs=[first_ref, second_ref],
+        )
+    )
+
+    assert result == {"ok": True}
+    method, url, kwargs = api.requests[-1]
+    assert method == "POST"
+    assert url.endswith("/accounting/cutover/analyze/")
+    assert [field for field, _upload in kwargs["files"]] == ["files", "files"]
+    assert [upload[0] for _field, upload in kwargs["files"]] == [
+        "DTVF_Buchungsstapel_1.csv",
+        "DTVF_Buchungsstapel_2.csv",
+    ]
+    assert all(upload[1].closed for _field, upload in kwargs["files"])
+
+
+def test_cutover_analysis_rejects_expired_file_reference_without_request() -> None:
+    mcp, api = registered_tools()
+
+    result = asyncio.run(
+        mcp.tools["analyze_accounting_cutover_documents"](
+            context_for(api),
+            file_refs=["ref_expired"],
+        )
+    )
+
+    assert "expired" in result["error"]
+    assert api.requests == []
+
+
+def test_cutover_manual_preview_is_read_only_json_request() -> None:
+    mcp, api = registered_tools()
+    balances = [
+        {
+            "account_code": "1200",
+            "side": "debit",
+            "amount": "100.00",
+            "memo": "Bank",
+        }
+    ]
+
+    result = asyncio.run(
+        mcp.tools["preview_accounting_cutover"](
+            context_for(api),
+            mode="year_start",
+            fiscal_year_begin="2026-01-01",
+            fiscal_year_end="2026-12-31",
+            cutover_date="2026-01-01",
+            opening_method="manual",
+            opening_file_ref=None,
+            booking_file_refs=None,
+            parties_file_ref=None,
+            assets_file_ref=None,
+            manual_balance_date="2025-12-31",
+            manual_balances=balances,
+        )
+    )
+
+    assert result == {"ok": True}
+    method, url, kwargs = api.requests[-1]
+    assert method == "POST"
+    assert url.endswith("/accounting/cutover/preview/")
+    assert kwargs["files"] is None
+    assert kwargs["json_data"] == {
+        "mode": "year_start",
+        "opening_method": "manual",
+        "fiscal_year_begin": "2026-01-01",
+        "fiscal_year_end": "2026-12-31",
+        "cutover_date": "2026-01-01",
+        "manual_balance_date": "2025-12-31",
+        "manual_balances": balances,
+    }
+
+
+def test_cutover_preview_serializes_manual_balances_with_supporting_file() -> None:
+    mcp, api = registered_tools()
+    parties_ref = store_file(b"parties", "customers-and-vendors.csv")
+    balances = [{"account_code": "1200", "side": "debit", "amount": "1.00"}]
+
+    asyncio.run(
+        mcp.tools["preview_accounting_cutover"](
+            context_for(api),
+            mode="year_start",
+            fiscal_year_begin="2026-01-01",
+            fiscal_year_end="2026-12-31",
+            cutover_date="2026-01-01",
+            opening_method="manual",
+            opening_file_ref=None,
+            booking_file_refs=None,
+            parties_file_ref=parties_ref,
+            assets_file_ref=None,
+            manual_balance_date="2025-12-31",
+            manual_balances=balances,
+        )
+    )
+
+    _method, _url, kwargs = api.requests[-1]
+    assert [field for field, _upload in kwargs["files"]] == ["parties_file"]
+    assert json.loads(kwargs["json_data"]["manual_balances"]) == balances
+
+
+def test_cutover_apply_requires_confirmation_then_posts_exact_payload() -> None:
+    mcp, api = registered_tools()
+    context = context_for(api)
+    arguments = {
+        "mode": "year_start",
+        "fiscal_year_begin": "2026-01-01",
+        "fiscal_year_end": "2026-12-31",
+        "cutover_date": "2026-01-01",
+        "opening_method": "manual",
+        "opening_file_ref": None,
+        "booking_file_refs": None,
+        "parties_file_ref": None,
+        "assets_file_ref": None,
+        "manual_balance_date": "2025-12-31",
+        "manual_balances": [{"account_code": "1200", "side": "debit", "amount": "100.00"}],
+    }
+
+    warning = asyncio.run(
+        mcp.tools["apply_accounting_cutover"](
+            context,
+            confirmed=False,
+            **arguments,
+        )
+    )
+    assert warning["confirmationRequired"] is True
+    assert api.requests == []
+
+    result = asyncio.run(
+        mcp.tools["apply_accounting_cutover"](
+            context,
+            confirmed=True,
+            **arguments,
+        )
+    )
+
+    assert result == {"ok": True}
+    method, url, kwargs = api.requests[-1]
+    assert method == "POST"
+    assert url.endswith("/accounting/cutover/import/")
+    assert kwargs["json_data"]["manual_balances"] == arguments["manual_balances"]
 
 
 def test_annual_close_creation_is_draft_only() -> None:


### PR DESCRIPTION
## Summary

- add read-only analysis of DATEV and supporting migration files, including server-side file-role and SKR detection
- add a safe Preview path for DATEV or manual opening balances
- add an explicit-confirmation Apply action for writing the reviewed cutover into the Ledger
- document the agent workflow as an MCP skill

## Safety

- analysis and Preview never write Ledger data
- Apply requires `confirmed=true` after reviewing the exact same inputs
- uploads remain short-lived `file_ref` values and local paths are not exposed
- no ELSTER submission or annual-close locking capability is added

## Tests

- `python /Users/mac/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/accounting-cutover`
- `uv run --extra dev pytest -q tests/test_accounting_tools.py` (11 passed)
- `uv run --extra dev pytest -q --ignore=tests/test_basic.py` (73 passed, 3 skipped)

`tests/test_basic.py` remains excluded because it imports the removed legacy `Config` class on `main`; this PR does not change that baseline issue.
