### PR TITLE
feat: add interactive accounting MCP apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ Before connecting, [create a free Norman account](https://app.norman.finance/sig
 1. Go to [Claude Connectors](https://claude.ai/new#settings/customize-connectors)
 2. Click **Add**
 3. Find and connect: **Norman Finance**
+
+MCP Apps-compatible Claude hosts can also open Norman's read-only **Document
+Review**, **Reconciliation Cockpit**, and **Ledger Explorer** directly in the
+conversation. Other Claude clients receive the same data as normal tool output.
 </details>
 
 <details>
@@ -155,6 +159,10 @@ claude /plugin install github:norman-finance/norman-mcp-server
 <br/>
 
 1. Install it from the official [ChatGPT Plugins Directory](https://chatgpt.com/plugins/plugin_asdk_app_6981ec32565481919b1c5a1627b1e330).
+
+The plugin includes interactive, read-only views for reviewing documents,
+reconciliation issues, and Ledger accounts. The accounting API remains the
+source of truth; write actions still require their normal tools and approvals.
 
 </details>
 

--- a/norman_mcp/apps/__init__.py
+++ b/norman_mcp/apps/__init__.py
@@ -1,0 +1,5 @@
+"""Portable interactive views exposed by the public Norman MCP server."""
+
+from norman_mcp.apps.public import register_public_apps
+
+__all__ = ["register_public_apps"]

--- a/norman_mcp/apps/accounting_workbench.html
+++ b/norman_mcp/apps/accounting_workbench.html
@@ -1,0 +1,211 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Norman Accounting Workbench</title>
+  <style>
+    :root { color-scheme: light dark; --ink:#171717; --muted:#6b6b6b; --line:#e7e7e5; --panel:#f7f7f5; --accent:#111; --bad:#9b2c2c; --warn:#8a5a00; --good:#17643b; --surface:#fff; }
+    @media (prefers-color-scheme:dark) { :root { --ink:#f5f5f2; --muted:#aaa; --line:#363634; --panel:#222220; --accent:#fff; --bad:#ff9a9a; --warn:#ffc565; --good:#7ee2a8; --surface:#171716; } }
+    * { box-sizing:border-box; }
+    body { margin:0; background:var(--surface); color:var(--ink); font:14px/1.45 ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+    button,input,select { font:inherit; }
+    button { color:inherit; }
+    .app { min-height:360px; padding:18px; }
+    .top { display:flex; justify-content:space-between; align-items:flex-start; gap:16px; }
+    h1 { font-size:20px; line-height:1.2; margin:0; }
+    .eyebrow { color:var(--muted); font-size:11px; font-weight:700; letter-spacing:.09em; margin-bottom:5px; text-transform:uppercase; }
+    .tabs { display:flex; gap:4px; margin:16px 0; padding-bottom:10px; border-bottom:1px solid var(--line); overflow:auto; }
+    .tab,.filter,.ghost,.primary { border:1px solid transparent; background:transparent; border-radius:999px; cursor:pointer; padding:7px 11px; white-space:nowrap; }
+    .tab:hover,.filter:hover,.ghost:hover { background:var(--panel); }
+    .tab.active,.filter.active { border-color:var(--ink); }
+    .primary { border-radius:6px; background:var(--accent); color:var(--surface); font-weight:650; }
+    .ghost { border-color:var(--line); border-radius:6px; }
+    .summary { display:grid; grid-template-columns:repeat(auto-fit,minmax(115px,1fr)); gap:8px; margin-bottom:14px; }
+    .metric { background:var(--panel); border:1px solid var(--line); border-radius:8px; padding:10px 12px; }
+    .metric strong { display:block; font-size:19px; }
+    .metric span { color:var(--muted); font-size:12px; }
+    .toolbar { display:flex; flex-wrap:wrap; gap:8px; align-items:center; margin-bottom:12px; }
+    .toolbar input { min-width:180px; flex:1; border:1px solid var(--line); background:var(--surface); color:var(--ink); border-radius:6px; padding:8px 10px; }
+    .filters { display:flex; flex-wrap:wrap; gap:4px; }
+    .table-wrap { overflow:auto; border:1px solid var(--line); border-radius:8px; }
+    table { width:100%; border-collapse:collapse; min-width:650px; }
+    th { color:var(--muted); font-size:11px; letter-spacing:.04em; text-align:left; text-transform:uppercase; }
+    th,td { border-bottom:1px solid var(--line); padding:10px 12px; vertical-align:top; }
+    tr:last-child td { border-bottom:0; }
+    tbody tr[data-selectable="true"] { cursor:pointer; }
+    tbody tr[data-selectable="true"]:hover { background:var(--panel); }
+    .num { font-variant-numeric:tabular-nums; text-align:right; white-space:nowrap; }
+    .badge { display:inline-block; border:1px solid var(--line); border-radius:999px; font-size:11px; margin:1px 3px 1px 0; padding:2px 7px; white-space:nowrap; }
+    .badge.bad { border-color:color-mix(in srgb,var(--bad) 45%,transparent); color:var(--bad); }
+    .badge.warn { border-color:color-mix(in srgb,var(--warn) 45%,transparent); color:var(--warn); }
+    .badge.good { border-color:color-mix(in srgb,var(--good) 45%,transparent); color:var(--good); }
+    .muted { color:var(--muted); }
+    .empty,.error { border:1px dashed var(--line); border-radius:8px; color:var(--muted); padding:30px; text-align:center; }
+    .error { border-color:var(--bad); color:var(--bad); }
+    .detail { display:grid; grid-template-columns:minmax(0,1fr) 260px; gap:14px; }
+    .inspector { background:var(--panel); border:1px solid var(--line); border-radius:8px; padding:14px; }
+    .inspector h2 { font-size:15px; margin:0 0 10px; }
+    .kv { display:grid; grid-template-columns:90px 1fr; gap:6px 10px; margin-bottom:14px; }
+    .kv dt { color:var(--muted); }
+    .kv dd { margin:0; overflow-wrap:anywhere; }
+    .loading { align-items:center; background:color-mix(in srgb,var(--surface) 88%,transparent); display:none; inset:0; justify-content:center; position:absolute; z-index:3; }
+    .loading.show { display:flex; }
+    .shell { position:relative; }
+    @media (max-width:720px) { .app{padding:12px}.detail{grid-template-columns:1fr}.inspector{order:-1}.top{display:block}.primary{margin-top:10px} }
+  </style>
+</head>
+<body>
+  <main class="app shell">
+    <div id="loading" class="loading">Loading…</div>
+    <div class="top">
+      <div><div class="eyebrow">Norman Finance</div><h1 id="title">Accounting Workbench</h1></div>
+      <button id="ask" class="primary" type="button">Ask AI about this</button>
+    </div>
+    <nav class="tabs" aria-label="Accounting views">
+      <button class="tab" data-view="documents" type="button">Document Review</button>
+      <button class="tab" data-view="reconciliation" type="button">Reconciliation</button>
+      <button class="tab" data-view="ledger" type="button">Ledger Explorer</button>
+    </nav>
+    <section id="content" aria-live="polite"><div class="empty">Waiting for Norman data…</div></section>
+  </main>
+  <script>
+    (() => {
+      const state = { data:null, selected:null, issue:"all", query:"", pending:new Map(), requestId:1, bridgeReady:false };
+      const tools = {
+        documents:"get_document_review_data",
+        reconciliation:"get_reconciliation_cockpit_data",
+        ledger:"get_ledger_explorer_data"
+      };
+      const title = document.getElementById("title");
+      const content = document.getElementById("content");
+      const loading = document.getElementById("loading");
+      const esc = value => String(value ?? "").replace(/[&<>"']/g, char => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"})[char]);
+      const num = (value, currency="EUR") => {
+        const parsed = Number(value ?? 0);
+        try { return new Intl.NumberFormat(document.documentElement.lang || "en", {style:"currency",currency:currency || "EUR"}).format(Number.isFinite(parsed) ? parsed : 0); }
+        catch { return `${Number.isFinite(parsed) ? parsed.toFixed(2) : value} ${currency || ""}`.trim(); }
+      };
+      const date = value => value ? esc(String(value).slice(0,10)) : "—";
+      const getStructured = result => {
+        if (result?.structuredContent) return result.structuredContent;
+        const text = result?.content?.find?.(item => item.type === "text")?.text;
+        if (text) { try { return JSON.parse(text); } catch {} }
+        return result;
+      };
+      function request(method, params, timeout=12000) {
+        const id = state.requestId++;
+        window.parent.postMessage({jsonrpc:"2.0",id,method,params}, "*");
+        return new Promise((resolve,reject) => {
+          const timer = setTimeout(() => { state.pending.delete(id); reject(new Error("Host request timed out")); }, timeout);
+          state.pending.set(id,{resolve,reject,timer});
+        });
+      }
+      async function initializeApp() {
+        try {
+          await request("ui/initialize",{
+            protocolVersion:"2026-01-26",
+            appInfo:{name:"Norman Accounting Workbench",version:"1.0.0"},
+            appCapabilities:{availableDisplayModes:["inline"]}
+          },5000);
+          state.bridgeReady=true;
+          window.parent.postMessage({jsonrpc:"2.0",method:"ui/notifications/initialized",params:{}},"*");
+        } catch {
+          // ChatGPT can hydrate the same widget through window.openai instead.
+        }
+      }
+      async function callTool(name, args={}) {
+        if (state.bridgeReady || !window.openai?.callTool) return request("tools/call",{name,arguments:args});
+        return window.openai.callTool(name,args);
+      }
+      async function sendMessage(prompt) {
+        if (state.bridgeReady || !window.openai?.sendFollowUpMessage) return request("ui/message",{role:"user",content:[{type:"text",text:prompt}]},5000);
+        return window.openai.sendFollowUpMessage({prompt});
+      }
+      function showLoading(show) { loading.classList.toggle("show",show); }
+      function metrics(summary={}) {
+        return `<div class="summary">${Object.entries(summary).map(([key,value]) => `<div class="metric"><strong>${esc(value)}</strong><span>${esc(key.replace(/([A-Z])/g," $1"))}</span></div>`).join("")}</div>`;
+      }
+      function toolbar(filters=[]) {
+        return `<div class="toolbar"><input id="search" value="${esc(state.query)}" placeholder="Filter visible rows"><div class="filters">${filters.map(([key,label]) => `<button class="filter ${state.issue===key?"active":""}" data-issue="${esc(key)}" type="button">${esc(label)}</button>`).join("")}</div></div>`;
+      }
+      function documentView(data) {
+        const rows=(data.items||[]).filter(item => {
+          const hay=`${item.fileName} ${item.brand} ${item.number} ${item.description}`.toLowerCase();
+          const matchesQuery=!state.query || hay.includes(state.query.toLowerCase());
+          const matchesIssue=state.issue==="all" || (state.issue==="linked" ? item.linked : !item.linked);
+          return matchesQuery && matchesIssue;
+        });
+        const selected=state.selected && (data.items||[]).find(item=>item.id===state.selected);
+        const table=`<div class="table-wrap"><table><thead><tr><th>Document</th><th>Supplier</th><th>Date</th><th class="num">Amount</th><th>Status</th></tr></thead><tbody>${rows.map(item=>`<tr data-selectable="true" data-id="${esc(item.id)}"><td><strong>${esc(item.fileName||"Untitled")}</strong><br><span class="muted">${esc(item.type||"")}</span></td><td>${esc(item.brand||item.description||"—")}</td><td>${date(item.date)}</td><td class="num">${num(item.amount,item.currency)}</td><td><span class="badge ${item.linked?"good":"warn"}">${esc(item.status)}</span></td></tr>`).join("")}</tbody></table></div>`;
+        const inspector=selected?`<aside class="inspector"><h2>${esc(selected.fileName)}</h2><dl class="kv"><dt>Supplier</dt><dd>${esc(selected.brand||"—")}</dd><dt>Number</dt><dd>${esc(selected.number||"—")}</dd><dt>VAT</dt><dd>${esc(selected.vatRate??"—")}%</dd><dt>Linked</dt><dd>${selected.linked?"Yes":"No"}</dd></dl><button class="ghost row-ask" data-kind="document" data-id="${esc(selected.id)}" type="button">Review in chat</button></aside>`:"";
+        return `${metrics(data.summary)}${toolbar([["all","All"],["unmatched","Needs match"],["linked","Linked"]])}<div class="detail"><div>${rows.length?table:'<div class="empty">No documents match this filter.</div>'}</div>${inspector}</div>`;
+      }
+      function reconciliationView(data) {
+        const rows=(data.items||[]).filter(item => {
+          const hay=`${item.description} ${item.categoryCode} ${item.categoryName} ${(item.issues||[]).join(" ")}`.toLowerCase();
+          const matchesQuery=!state.query || hay.includes(state.query.toLowerCase());
+          const matchesIssue=state.issue==="all" || (item.issues||[]).includes(state.issue);
+          return matchesQuery && matchesIssue;
+        });
+        const table=`<div class="table-wrap"><table><thead><tr><th>Transaction</th><th>Category</th><th class="num">Amount</th><th>Issues</th><th></th></tr></thead><tbody>${rows.map(item=>`<tr><td><strong>${esc(item.description||"Untitled")}</strong><br><span class="muted">${date(item.date)} · ${esc(item.cashflowType)}</span></td><td>${esc([item.categoryCode,item.categoryName].filter(Boolean).join(" · ")||"—")}</td><td class="num">${num(item.amount,item.currency)}</td><td>${(item.issues||[]).length?(item.issues||[]).map(issue=>`<span class="badge ${issue==="Previous SKR"?"bad":"warn"}">${esc(issue)}</span>`).join(""):'<span class="badge good">Ready</span>'}</td><td><button class="ghost row-ask" data-kind="transaction" data-id="${esc(item.id)}" type="button">Review</button></td></tr>`).join("")}</tbody></table></div>`;
+        return `${metrics(data.summary)}${toolbar([["all","All"],["Missing document","Missing document"],["Uncategorized","Uncategorized"],["Previous SKR","Previous SKR"]])}${rows.length?table:'<div class="empty">No transactions match this filter.</div>'}`;
+      }
+      function ledgerView(data) {
+        if (data.mode==="account") {
+          const account=data.account||{};
+          const rows=data.items||[];
+          return `<div class="toolbar"><button id="ledger-back" class="ghost" type="button">← All accounts</button><strong>Account ${esc(account.code||"")}</strong></div>${metrics({debit:account.debit??0,credit:account.credit??0,balance:account.balance??0,postings:rows.length})}<div class="table-wrap"><table><thead><tr><th>Date</th><th>Entry</th><th>Memo</th><th>Debit</th><th>Credit</th><th class="num">Amount</th><th class="num">Running balance</th></tr></thead><tbody>${rows.map(item=>`<tr><td>${date(item.date)}</td><td>${esc(item.entryNo||"—")}</td><td>${esc(item.memo||item.origin||"—")}${item.locked?' <span class="badge">Locked</span>':''}</td><td>${esc(item.debitCode)}</td><td>${esc(item.creditCode)}</td><td class="num">${num(item.signedAmount)}</td><td class="num">${num(item.runningBalance)}</td></tr>`).join("")}</tbody></table></div>`;
+        }
+        const rows=(data.items||[]).filter(item => !state.query || `${item.code} ${item.name}`.toLowerCase().includes(state.query.toLowerCase()));
+        return `${metrics(data.summary)}${toolbar([])}<div class="table-wrap"><table><thead><tr><th>Account</th><th>Name</th><th class="num">Debit</th><th class="num">Credit</th><th class="num">Balance</th></tr></thead><tbody>${rows.map(item=>`<tr data-selectable="true" data-code="${esc(item.code)}"><td><strong>${esc(item.code)}</strong></td><td>${esc(item.name||"—")}</td><td class="num">${num(item.debit)}</td><td class="num">${num(item.credit)}</td><td class="num">${num(item.balance)}</td></tr>`).join("")}</tbody></table></div>`;
+      }
+      function render(data) {
+        if (!data || typeof data!=="object") return;
+        state.data=data; state.selected=null;
+        title.textContent=data.title||"Accounting Workbench";
+        document.querySelectorAll(".tab").forEach(tab=>tab.classList.toggle("active",tab.dataset.view===data.view));
+        if (data.error) content.innerHTML=`<div class="error">${esc(data.error)}</div>`;
+        else if (data.view==="documents") content.innerHTML=documentView(data);
+        else if (data.view==="reconciliation") content.innerHTML=reconciliationView(data);
+        else if (data.view==="ledger") content.innerHTML=ledgerView(data);
+        else content.innerHTML='<div class="empty">Unsupported view.</div>';
+        bindContent();
+      }
+      function rerender() { if (state.data) render({...state.data}); }
+      function bindContent() {
+        document.getElementById("search")?.addEventListener("input",event=>{state.query=event.target.value;rerender();});
+        document.querySelectorAll("[data-issue]").forEach(button=>button.addEventListener("click",()=>{state.issue=button.dataset.issue;rerender();}));
+        document.querySelectorAll("tr[data-id]").forEach(row=>row.addEventListener("click",()=>{state.selected=row.dataset.id;content.innerHTML=documentView(state.data);bindContent();}));
+        document.querySelectorAll(".row-ask").forEach(button=>button.addEventListener("click",async event=>{event.stopPropagation();await sendMessage(`Review Norman ${button.dataset.kind} ${button.dataset.id}. Explain what needs attention and do not change anything without my confirmation.`);}));
+        document.querySelectorAll("tr[data-code]").forEach(row=>row.addEventListener("click",()=>loadView("ledger",row.dataset.code)));
+        document.getElementById("ledger-back")?.addEventListener("click",()=>loadView("ledger"));
+      }
+      async function loadView(view, accountCode=null) {
+        showLoading(true); state.query=""; state.issue="all";
+        try {
+          const filters=state.data?.filters||{};
+          const args=view==="ledger"?{date_from:filters.dateFrom||null,date_to:filters.dateTo||null,account_code:accountCode}:{};
+          const result=await callTool(tools[view],args);
+          render(getStructured(result));
+        } catch (error) { content.innerHTML=`<div class="error">${esc(error?.message||error)}</div>`; }
+        finally { showLoading(false); }
+      }
+      document.querySelectorAll(".tab").forEach(tab=>tab.addEventListener("click",()=>loadView(tab.dataset.view)));
+      document.getElementById("ask").addEventListener("click",()=>sendMessage(`Review the current Norman ${state.data?.title||"accounting"} view. Summarize the important issues and suggest the next safe step without changing data.`));
+      window.addEventListener("message",event=>{
+        if (event.source!==window.parent) return;
+        const message=event.data;
+        if (!message || message.jsonrpc!=="2.0") return;
+        if (message.id!==undefined && state.pending.has(message.id)) {
+          const pending=state.pending.get(message.id); state.pending.delete(message.id); clearTimeout(pending.timer);
+          message.error?pending.reject(message.error):pending.resolve(message.result); return;
+        }
+        if (message.method==="ui/notifications/tool-result") render(message.params?.structuredContent);
+      },{passive:true});
+      initializeApp();
+      if (window.openai?.toolOutput) render(window.openai.toolOutput);
+    })();
+  </script>
+</body>
+</html>

--- a/norman_mcp/apps/public.py
+++ b/norman_mcp/apps/public.py
@@ -1,0 +1,459 @@
+"""Read-only MCP Apps for Norman's public connector.
+
+The tools in this module deliberately reuse Norman's existing REST API.  The
+API remains authoritative; the embedded UI only presents compact, normalized
+read models.  Data tools stay useful in hosts without MCP Apps support, while
+the matching render tools progressively enhance the result in compatible
+hosts such as ChatGPT and Claude.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+from urllib.parse import urljoin
+
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
+from pydantic import Field
+
+from norman_mcp import config
+from norman_mcp.context import Context
+
+APP_RESOURCE_URI = "ui://norman/accounting-workbench-v1.html"
+APP_MIME_TYPE = "text/html;profile=mcp-app"
+
+READ_ONLY = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+)
+
+
+def _api_and_company(ctx: Context) -> tuple[Any, Optional[str], Optional[Dict[str, Any]]]:
+    api = ctx.request_context.lifespan_context["api"]
+    company_id = api.company_id
+    if not company_id:
+        return (
+            api,
+            None,
+            {"error": "No company available. Please authenticate and select a company first."},
+        )
+    return api, company_id, None
+
+
+def _company_url(company_id: str, suffix: str) -> str:
+    return urljoin(
+        config.api_base_url,
+        f"api/v1/companies/{company_id}/{suffix.lstrip('/')}",
+    )
+
+
+def _items(payload: Any) -> list[Dict[str, Any]]:
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if isinstance(payload, dict):
+        rows = payload.get("results")
+        if isinstance(rows, list):
+            return [item for item in rows if isinstance(item, dict)]
+    return []
+
+
+def _first(item: Dict[str, Any], *keys: str, default: Any = None) -> Any:
+    for key in keys:
+        value = item.get(key)
+        if value is not None:
+            return value
+    return default
+
+
+def _name(value: Any) -> str:
+    if isinstance(value, dict):
+        return str(_first(value, "name", "nameEn", "name_en", "nameDe", "name_de", default=""))
+    return str(value or "")
+
+
+def _currency(value: Any) -> str:
+    if isinstance(value, dict):
+        return str(_first(value, "code", "symbol", "name", default="EUR"))
+    return str(value or "EUR")
+
+
+def _limited(rows: Iterable[Dict[str, Any]], limit: int) -> list[Dict[str, Any]]:
+    return list(rows)[:limit]
+
+
+def _document_row(item: Dict[str, Any]) -> Dict[str, Any]:
+    transactions = _first(item, "transactions", default=[])
+    transactions = transactions if isinstance(transactions, list) else []
+    linked = bool(transactions)
+    return {
+        "id": str(_first(item, "public_id", "publicId", "pk", default="")),
+        "fileName": str(
+            _first(item, "file_name", "fileName", default="")
+            or str(_first(item, "file", default="")).rsplit("/", 1)[-1]
+        ),
+        "type": str(_first(item, "attachment_type", "attachmentType", default="other")),
+        "brand": str(_first(item, "brand_name", "brandName", default="")),
+        "number": str(_first(item, "attachment_number", "attachmentNumber", default="")),
+        "date": str(_first(item, "value_date", "valueDate", "created", default="")),
+        "amount": _first(item, "amount", default=None),
+        "currency": _currency(_first(item, "currency", default="EUR")),
+        "vatRate": _first(item, "vat_rate", "vatRate", default=None),
+        "description": str(_first(item, "description", default="")),
+        "linked": linked,
+        "transactionIds": [str(value) for value in transactions],
+        "status": "Linked" if linked else "Needs match",
+    }
+
+
+def _category(item: Dict[str, Any]) -> tuple[str, str]:
+    value = _first(item, "company_category", "companyCategory", "category", default=None)
+    if not isinstance(value, dict):
+        return "", _name(value)
+    code = str(_first(value, "code", "accountNumber", "account_number", default=""))
+    return code, _name(value)
+
+
+def _transaction_row(item: Dict[str, Any]) -> Dict[str, Any]:
+    category_code, category_name = _category(item)
+    attachment = _first(item, "attachment", default=None)
+    extras = _first(item, "additional_attachments", "additionalAttachments", default=[])
+    document_not_required = bool(
+        _first(item, "document_not_required", "documentNotRequired", default=False)
+    )
+    has_document = bool(attachment) or bool(extras) or document_not_required
+    user_status = str(_first(item, "user_status", "userStatus", "status", default=""))
+    categorization_status = str(
+        _first(item, "categorization_status", "categorizationStatus", default="")
+    )
+    uses_previous_skr = bool(
+        _first(item, "uses_previous_skr_account", "usesPreviousSkrAccount", default=False)
+    )
+    issues: list[str] = []
+    if not has_document:
+        issues.append("Missing document")
+    if not category_code and not category_name:
+        issues.append("Uncategorized")
+    if user_status.upper() not in {"VERIFIED", "FINALIZED"}:
+        issues.append("Needs review")
+    if categorization_status.lower() in {"failed", "pending", "needs_review"}:
+        issues.append("Categorization pending")
+    if uses_previous_skr:
+        issues.append("Previous SKR")
+
+    return {
+        "id": str(_first(item, "public_id", "publicId", "pk", default="")),
+        "date": str(_first(item, "value_date", "valueDate", default="")),
+        "description": str(_first(item, "description", default="")),
+        "amount": _first(item, "amount", default=None),
+        "currency": _currency(_first(item, "currency", default="EUR")),
+        "cashflowType": str(_first(item, "cashflow_type", "cashflowType", default="")),
+        "categoryCode": category_code,
+        "categoryName": category_name,
+        "userStatus": user_status,
+        "locked": bool(_first(item, "is_locked", "isLocked", default=False)),
+        "hasDocument": has_document,
+        "documentNotRequired": document_not_required,
+        "issues": issues,
+    }
+
+
+def _account_row(item: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "code": str(_first(item, "code", "account", default="")),
+        "name": str(_first(item, "name", default="")),
+        "debit": _first(item, "debit_total", "debitTotal", "debit", default="0"),
+        "credit": _first(item, "credit_total", "creditTotal", "credit", default="0"),
+        "balance": _first(item, "saldo", "balance", "running_saldo", default="0"),
+    }
+
+
+def _posting_row(item: Dict[str, Any]) -> Dict[str, Any]:
+    origin = _first(item, "origin", default={})
+    origin_label = (
+        _name(origin) or str(_first(origin, "label", "type", default=""))
+        if isinstance(origin, dict)
+        else str(origin or "")
+    )
+    return {
+        "id": str(_first(item, "public_id", "publicId", default="")),
+        "entryNo": str(_first(item, "entry_no", "entryNo", default="")),
+        "date": str(_first(item, "booking_date", "bookingDate", default="")),
+        "debitCode": str(_first(item, "debit_code", "debitCode", default="")),
+        "creditCode": str(_first(item, "credit_code", "creditCode", default="")),
+        "amount": _first(item, "amount", default="0"),
+        "signedAmount": _first(item, "signed_amount", "signedAmount", default="0"),
+        "runningBalance": _first(item, "running_saldo", "runningSaldo", default="0"),
+        "memo": str(_first(item, "memo", default="")),
+        "source": str(_first(item, "source", default="")),
+        "origin": origin_label,
+        "taxTreatment": str(_first(item, "tax_treatment", "taxTreatment", default="")),
+        "locked": bool(_first(item, "locked_at", "lockedAt", default=False)),
+    }
+
+
+def _error_view(view: str, title: str, error: Any) -> Dict[str, Any]:
+    return {"view": view, "title": title, "error": str(error), "items": [], "summary": {}}
+
+
+def _render_result(view: str, title: str, payload: Dict[str, Any]) -> CallToolResult:
+    data = dict(payload)
+    data["view"] = view
+    data["title"] = title
+    count = len(data.get("items", [])) if isinstance(data.get("items"), list) else 0
+    return CallToolResult(
+        content=[
+            TextContent(
+                type="text",
+                text=f"Opened {title} with {count} visible row{'s' if count != 1 else ''}.",
+            )
+        ],
+        structuredContent=data,
+        _meta={"norman/view": view},
+    )
+
+
+def _render_meta(invoking: str, invoked: str) -> Dict[str, Any]:
+    return {
+        "ui": {"resourceUri": APP_RESOURCE_URI},
+        "openai/outputTemplate": APP_RESOURCE_URI,
+        "openai/toolInvocation/invoking": invoking,
+        "openai/toolInvocation/invoked": invoked,
+    }
+
+
+def register_public_apps(mcp: Any) -> None:
+    """Register the public connector's portable accounting workbench."""
+
+    @mcp.resource(
+        APP_RESOURCE_URI,
+        name="norman-accounting-workbench",
+        title="Norman Accounting Workbench",
+        description="Interactive document, reconciliation and Ledger views.",
+        mime_type=APP_MIME_TYPE,
+        meta={
+            "ui": {
+                "prefersBorder": True,
+                "csp": {"connectDomains": [], "resourceDomains": []},
+            },
+            "openai/widgetDescription": (
+                "A read-only Norman accounting workbench for reviewing documents, "
+                "reconciliation issues and Ledger account postings."
+            ),
+            "openai/widgetPrefersBorder": True,
+            "openai/widgetCSP": {
+                "connect_domains": [],
+                "resource_domains": [],
+            },
+        },
+    )
+    async def accounting_workbench() -> str:
+        return (Path(__file__).with_name("accounting_workbench.html")).read_text(encoding="utf-8")
+
+    @mcp.tool(title="Get Document Review Data", annotations=READ_ONLY)
+    async def get_document_review_data(
+        ctx: Context,
+        search: Optional[str] = Field(
+            default=None, description="File name, supplier, description or document number"
+        ),
+        date_from: Optional[str] = Field(default=None, description="YYYY-MM-DD"),
+        date_to: Optional[str] = Field(default=None, description="YYYY-MM-DD"),
+        linked: Optional[bool] = Field(
+            default=None,
+            description="True for linked documents, false for documents needing a match",
+        ),
+        limit: int = Field(default=30, ge=1, le=100),
+    ) -> Dict[str, Any]:
+        """Use this when reviewing extracted documents or finding unmatched receipts."""
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return _error_view("documents", "Document Review", error["error"])
+        response = await api.arequest(
+            "GET",
+            _company_url(company_id, "attachments/"),
+            params={
+                key: value
+                for key, value in {
+                    "search": search,
+                    "date_from": date_from,
+                    "date_to": date_to,
+                    "ordering": "-created",
+                    "pageSize": limit,
+                }.items()
+                if value is not None
+            },
+        )
+        if isinstance(response, dict) and response.get("error"):
+            return _error_view("documents", "Document Review", response["error"])
+        rows = [_document_row(item) for item in _items(response)]
+        if linked is not None:
+            rows = [row for row in rows if row["linked"] is linked]
+        rows = _limited(rows, limit)
+        return {
+            "view": "documents",
+            "title": "Document Review",
+            "items": rows,
+            "summary": {
+                "total": len(rows),
+                "linked": sum(1 for row in rows if row["linked"]),
+                "needsMatch": sum(1 for row in rows if not row["linked"]),
+            },
+            "filters": {
+                "search": search or "",
+                "dateFrom": date_from or "",
+                "dateTo": date_to or "",
+                "linked": linked,
+            },
+        }
+
+    @mcp.tool(
+        title="Render Document Review",
+        description=(
+            "Render the interactive Document Review. Always call get_document_review_data "
+            "first and pass its complete result as payload."
+        ),
+        annotations=READ_ONLY,
+        meta=_render_meta("Opening document review…", "Document review ready"),
+    )
+    async def render_document_review(
+        ctx: Context,
+        payload: Dict[str, Any] = Field(
+            description="Complete result returned by get_document_review_data"
+        ),
+    ) -> CallToolResult:
+        del ctx
+        return _render_result("documents", "Document Review", payload)
+
+    @mcp.tool(title="Get Reconciliation Cockpit Data", annotations=READ_ONLY)
+    async def get_reconciliation_cockpit_data(
+        ctx: Context,
+        date_from: Optional[str] = Field(default=None, description="YYYY-MM-DD"),
+        date_to: Optional[str] = Field(default=None, description="YYYY-MM-DD"),
+        limit: int = Field(default=50, ge=1, le=100),
+    ) -> Dict[str, Any]:
+        """Use this when checking transactions that need documents, categories or review."""
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return _error_view("reconciliation", "Reconciliation Cockpit", error["error"])
+        response = await api.arequest(
+            "GET",
+            _company_url(company_id, "accounting/transactions/"),
+            params={
+                key: value
+                for key, value in {
+                    "dateFrom": date_from,
+                    "dateTo": date_to,
+                    "limit": limit,
+                }.items()
+                if value is not None
+            },
+        )
+        if isinstance(response, dict) and response.get("error"):
+            return _error_view("reconciliation", "Reconciliation Cockpit", response["error"])
+        rows = _limited((_transaction_row(item) for item in _items(response)), limit)
+        return {
+            "view": "reconciliation",
+            "title": "Reconciliation Cockpit",
+            "items": rows,
+            "summary": {
+                "total": len(rows),
+                "needsAttention": sum(1 for row in rows if row["issues"]),
+                "missingDocuments": sum(1 for row in rows if "Missing document" in row["issues"]),
+                "uncategorized": sum(1 for row in rows if "Uncategorized" in row["issues"]),
+                "previousSkr": sum(1 for row in rows if "Previous SKR" in row["issues"]),
+            },
+            "filters": {"dateFrom": date_from or "", "dateTo": date_to or ""},
+        }
+
+    @mcp.tool(
+        title="Render Reconciliation Cockpit",
+        description=(
+            "Render the interactive Reconciliation Cockpit. Always call "
+            "get_reconciliation_cockpit_data first and pass its complete result as payload."
+        ),
+        annotations=READ_ONLY,
+        meta=_render_meta("Opening reconciliation…", "Reconciliation ready"),
+    )
+    async def render_reconciliation_cockpit(
+        ctx: Context,
+        payload: Dict[str, Any] = Field(
+            description="Complete result returned by get_reconciliation_cockpit_data"
+        ),
+    ) -> CallToolResult:
+        del ctx
+        return _render_result("reconciliation", "Reconciliation Cockpit", payload)
+
+    @mcp.tool(title="Get Ledger Explorer Data", annotations=READ_ONLY)
+    async def get_ledger_explorer_data(
+        ctx: Context,
+        date_from: Optional[str] = Field(default=None, description="YYYY-MM-DD"),
+        date_to: Optional[str] = Field(default=None, description="YYYY-MM-DD"),
+        account_code: Optional[str] = Field(
+            default=None,
+            description="Account code to expand into its Kontenblatt; omit for the SuSa",
+        ),
+    ) -> Dict[str, Any]:
+        """Use this when exploring account balances and drilling into Ledger postings."""
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return _error_view("ledger", "Ledger Explorer", error["error"])
+        endpoint = "accounting/ledger/accounts/"
+        if account_code:
+            endpoint = f"accounting/ledger/accounts/{account_code}/"
+        response = await api.arequest(
+            "GET",
+            _company_url(company_id, endpoint),
+            params={
+                key: value
+                for key, value in {"dateFrom": date_from, "dateTo": date_to}.items()
+                if value is not None
+            },
+        )
+        if isinstance(response, dict) and response.get("error"):
+            return _error_view("ledger", "Ledger Explorer", response["error"])
+
+        if account_code:
+            rows = [_posting_row(item) for item in _items(response)]
+            return {
+                "view": "ledger",
+                "title": "Ledger Explorer",
+                "mode": "account",
+                "account": {
+                    "code": account_code,
+                    "debit": _first(response, "debit_total", "debitTotal", default="0"),
+                    "credit": _first(response, "credit_total", "creditTotal", default="0"),
+                    "balance": _first(response, "saldo", "balance", default="0"),
+                },
+                "items": rows,
+                "summary": {"postings": len(rows)},
+                "filters": {"dateFrom": date_from or "", "dateTo": date_to or ""},
+            }
+
+        rows = [_account_row(item) for item in _items(response)]
+        return {
+            "view": "ledger",
+            "title": "Ledger Explorer",
+            "mode": "accounts",
+            "items": rows,
+            "summary": {"accounts": len(rows)},
+            "filters": {"dateFrom": date_from or "", "dateTo": date_to or ""},
+        }
+
+    @mcp.tool(
+        title="Render Ledger Explorer",
+        description=(
+            "Render the interactive Ledger Explorer. Always call get_ledger_explorer_data "
+            "first and pass its complete result as payload."
+        ),
+        annotations=READ_ONLY,
+        meta=_render_meta("Opening Ledger…", "Ledger Explorer ready"),
+    )
+    async def render_ledger_explorer(
+        ctx: Context,
+        payload: Dict[str, Any] = Field(
+            description="Complete result returned by get_ledger_explorer_data"
+        ),
+    ) -> CallToolResult:
+        del ctx
+        return _render_result("ledger", "Ledger Explorer", payload)

--- a/norman_mcp/server.py
+++ b/norman_mcp/server.py
@@ -41,6 +41,7 @@ from norman_mcp.tools.gewerbe_registration import register_gewerbe_registration_
 from norman_mcp.tools.corporate_tax_registration import register_corporate_tax_registration_tools
 from norman_mcp.prompts.templates import register_prompts
 from norman_mcp.resources.endpoints import register_resources
+from norman_mcp.apps import register_public_apps
 from norman_mcp.auth.provider import NormanOAuthProvider
 from norman_mcp.auth.routes import create_norman_auth_routes
 
@@ -371,6 +372,7 @@ def create_app(host=None, port=None, public_url=None, transport="sse", streamabl
     register_corporate_tax_registration_tools(server)
     register_prompts(server)
     register_resources(server)
+    register_public_apps(server)
     
     return server
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ norman-mcp = "norman_mcp.cli:main"
 include = ["norman_mcp*"]
 
 [tool.setuptools.package-data]
-norman_mcp = ["static/*", "files/*"]
+norman_mcp = ["static/*", "files/*", "apps/*.html"]
 
 [tool.black]
 line-length = 100

--- a/tests/test_public_apps.py
+++ b/tests/test_public_apps.py
@@ -1,0 +1,233 @@
+"""Contract tests for the public connector's portable MCP Apps UI."""
+
+import asyncio
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any
+
+from mcp.types import CallToolResult
+
+from norman_mcp.apps.public import (
+    APP_MIME_TYPE,
+    APP_RESOURCE_URI,
+    register_public_apps,
+)
+
+
+class FakeMcp:
+    def __init__(self) -> None:
+        self.tools: dict[str, Callable[..., Any]] = {}
+        self.tool_options: dict[str, dict[str, Any]] = {}
+        self.resources: dict[str, Callable[..., Any]] = {}
+        self.resource_options: dict[str, dict[str, Any]] = {}
+
+    def tool(self, *args: Any, **kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        del args
+
+        def register(function: Callable[..., Any]) -> Callable[..., Any]:
+            self.tools[function.__name__] = function
+            self.tool_options[function.__name__] = kwargs
+            return function
+
+        return register
+
+    def resource(
+        self, uri: str, **kwargs: Any
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        def register(function: Callable[..., Any]) -> Callable[..., Any]:
+            self.resources[uri] = function
+            self.resource_options[uri] = kwargs
+            return function
+
+        return register
+
+
+class FakeApi:
+    company_id = "company-1"
+
+    def __init__(self) -> None:
+        self.requests: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def arequest(self, method: str, url: str, **kwargs: Any) -> dict[str, Any]:
+        self.requests.append((method, url, kwargs))
+        if url.endswith("/attachments/"):
+            return {
+                "results": [
+                    {
+                        "public_id": "doc-1",
+                        "file_name": "invoice.pdf",
+                        "brand_name": "Acme GmbH",
+                        "amount": "119.00",
+                        "currency": "EUR",
+                        "transactions": [],
+                    }
+                ]
+            }
+        if url.endswith("/accounting/transactions/"):
+            return {
+                "results": [
+                    {
+                        "public_id": "tx-1",
+                        "description": "Acme invoice",
+                        "amount": "119.00",
+                        "currency": {"code": "EUR"},
+                        "user_status": "UNVERIFIED",
+                        "company_category": None,
+                        "attachment": None,
+                    }
+                ]
+            }
+        if url.endswith("/accounting/ledger/accounts/1200/"):
+            return {
+                "code": "1200",
+                "debit_total": "100.00",
+                "credit_total": "20.00",
+                "saldo": "80.00",
+                "results": [
+                    {
+                        "public_id": "entry-1",
+                        "booking_date": "2026-01-03",
+                        "debit_code": "1200",
+                        "credit_code": "8400",
+                        "amount": "100.00",
+                        "signed_amount": "100.00",
+                        "running_saldo": "100.00",
+                    }
+                ],
+            }
+        if url.endswith("/accounting/ledger/accounts/"):
+            return {
+                "results": [
+                    {
+                        "code": "1200",
+                        "name": "Bank",
+                        "debit_total": "100.00",
+                        "credit_total": "20.00",
+                        "saldo": "80.00",
+                    }
+                ]
+            }
+        return {"results": []}
+
+
+def _context(api: FakeApi) -> SimpleNamespace:
+    return SimpleNamespace(request_context=SimpleNamespace(lifespan_context={"api": api}))
+
+
+def _registered() -> tuple[FakeMcp, FakeApi]:
+    mcp = FakeMcp()
+    api = FakeApi()
+    register_public_apps(mcp)
+    return mcp, api
+
+
+def test_registers_portable_resource_and_decoupled_tools() -> None:
+    mcp, _api = _registered()
+
+    assert APP_RESOURCE_URI in mcp.resources
+    assert mcp.resource_options[APP_RESOURCE_URI]["mime_type"] == APP_MIME_TYPE
+    assert mcp.resource_options[APP_RESOURCE_URI]["meta"]["ui"]["csp"] == {
+        "connectDomains": [],
+        "resourceDomains": [],
+    }
+    assert {
+        "get_document_review_data",
+        "render_document_review",
+        "get_reconciliation_cockpit_data",
+        "render_reconciliation_cockpit",
+        "get_ledger_explorer_data",
+        "render_ledger_explorer",
+    } == set(mcp.tools)
+    for name in (
+        "render_document_review",
+        "render_reconciliation_cockpit",
+        "render_ledger_explorer",
+    ):
+        meta = mcp.tool_options[name]["meta"]
+        assert meta["ui"]["resourceUri"] == APP_RESOURCE_URI
+        assert meta["openai/outputTemplate"] == APP_RESOURCE_URI
+
+
+def test_widget_is_self_contained_and_uses_standard_bridge() -> None:
+    mcp, _api = _registered()
+    html = asyncio.run(mcp.resources[APP_RESOURCE_URI]())
+
+    assert "ui/notifications/tool-result" in html
+    assert 'request("ui/initialize"' in html
+    assert 'method:"ui/notifications/initialized"' in html
+    assert 'appInfo:{name:"Norman Accounting Workbench"' in html
+    assert 'appCapabilities:{availableDisplayModes:["inline"]}' in html
+    assert "state.bridgeReady=true" in html
+    assert 'request("tools/call"' in html
+    assert 'request("ui/message"' in html
+    assert "https://" not in html
+
+
+def test_document_and_reconciliation_data_are_compact_and_actionable() -> None:
+    mcp, api = _registered()
+    ctx = _context(api)
+
+    documents = asyncio.run(
+        mcp.tools["get_document_review_data"](
+            ctx, search=None, date_from=None, date_to=None, linked=None, limit=30
+        )
+    )
+    reconciliation = asyncio.run(
+        mcp.tools["get_reconciliation_cockpit_data"](ctx, date_from=None, date_to=None, limit=50)
+    )
+
+    assert documents["items"][0] == {
+        "id": "doc-1",
+        "fileName": "invoice.pdf",
+        "type": "other",
+        "brand": "Acme GmbH",
+        "number": "",
+        "date": "",
+        "amount": "119.00",
+        "currency": "EUR",
+        "vatRate": None,
+        "description": "",
+        "linked": False,
+        "transactionIds": [],
+        "status": "Needs match",
+    }
+    assert reconciliation["summary"]["needsAttention"] == 1
+    assert reconciliation["items"][0]["issues"] == [
+        "Missing document",
+        "Uncategorized",
+        "Needs review",
+    ]
+
+
+def test_ledger_data_drills_down_without_mutation() -> None:
+    mcp, api = _registered()
+    ctx = _context(api)
+
+    accounts = asyncio.run(
+        mcp.tools["get_ledger_explorer_data"](ctx, date_from=None, date_to=None, account_code=None)
+    )
+    detail = asyncio.run(
+        mcp.tools["get_ledger_explorer_data"](
+            ctx, date_from=None, date_to=None, account_code="1200"
+        )
+    )
+
+    assert accounts["mode"] == "accounts"
+    assert accounts["items"][0]["balance"] == "80.00"
+    assert detail["mode"] == "account"
+    assert detail["account"]["code"] == "1200"
+    assert detail["items"][0]["runningBalance"] == "100.00"
+    assert all(method == "GET" for method, _url, _kwargs in api.requests)
+
+
+def test_render_tools_return_structured_content_and_widget_only_meta() -> None:
+    mcp, api = _registered()
+    result = asyncio.run(
+        mcp.tools["render_document_review"](
+            _context(api), payload={"items": [{"id": "doc-1"}], "summary": {"total": 1}}
+        )
+    )
+
+    assert isinstance(result, CallToolResult)
+    assert result.structuredContent["view"] == "documents"
+    assert result.meta == {"norman/view": "documents"}


### PR DESCRIPTION
## Summary

- add a portable MCP Apps accounting workbench to the public Norman MCP server
- provide interactive Document Review, Reconciliation Cockpit, and Ledger Explorer views
- use decoupled read-only data/render tools with the standard MCP Apps bridge and ChatGPT compatibility aliases
- package the self-contained UI resource and document ChatGPT/Claude host behavior

## Validation

- `pytest -q --ignore=tests/test_basic.py` (78 passed, 3 skipped)
- JavaScript syntax check with `node --check`
- Black, isort, and flake8 on the new app and contract tests
- real FastMCP tool/resource contract inspection
- wheel build includes `accounting_workbench.html`

## Scope

Public MCP only. The views are read-only; no internal MCP changes or accounting mutations are included.