### PR TITLE
docs: position Norman MCP for European businesses

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "email": "support@norman.finance"
   },
   "metadata": {
-    "description": "AI-powered bookkeeping, accounting, invoicing, and tax workflows through MCP.",
+    "description": "AI-powered bookkeeping, accounting, invoicing, and tax workflows for European businesses through MCP.",
     "version": "1.0.0"
   },
   "plugins": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
     "email": "support@norman.finance"
   },
   "metadata": {
-    "description": "AI-powered bookkeeping and tax filing automation for entrepreneurs at the heart of the European economy.",
+    "description": "AI-powered bookkeeping, accounting, invoicing, and tax workflows through MCP.",
     "version": "1.0.0"
   },
   "plugins": [
     {
       "name": "norman-finance",
       "source": "./",
-      "description": "Connect to Norman Finance to manage clients, invoices, transactions, taxes, and documents from your AI chat.",
+      "description": "Connect Norman Finance to your AI for bookkeeping, invoices, transactions, documents, ledgers, reports, and tax workflows.",
       "version": "1.0.0",
       "author": {
         "name": "Norman Finance"
@@ -22,12 +22,16 @@
       "license": "MIT",
       "keywords": [
         "finance",
+        "ai",
+        "automation",
         "bookkeeping",
         "accounting",
         "invoicing",
         "taxes",
-        "german",
+        "receipts",
+        "documents",
         "freelancer",
+        "ledger",
         "mcp",
         "oauth"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "norman-finance",
-  "description": "AI-powered bookkeeping, accounting, invoicing, and tax workflows through MCP.",
+  "description": "AI-powered bookkeeping, accounting, invoicing, and tax workflows for European businesses through MCP.",
   "version": "1.0.0",
   "author": {
     "name": "Norman Finance",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "norman-finance",
-  "description": "AI-powered bookkeeping and tax filing automation for entrepreneurs at the heart of the European economy. Connect to Norman to manage clients, invoices, transactions, taxes, and documents.",
+  "description": "AI-powered bookkeeping, accounting, invoicing, and tax workflows through MCP.",
   "version": "1.0.0",
   "author": {
     "name": "Norman Finance",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "norman-finance",
   "version": "1.0.0",
-  "description": "AI-powered bookkeeping, accounting, invoicing, and tax workflows through MCP.",
+  "description": "AI-powered bookkeeping, accounting, invoicing, and tax workflows for European businesses through MCP.",
   "author": {
     "name": "Norman Finance",
     "email": "support@norman.finance"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "norman-finance",
   "version": "1.0.0",
-  "description": "AI-powered bookkeeping and tax filing automation for entrepreneurs at the heart of the European economy.",
+  "description": "AI-powered bookkeeping, accounting, invoicing, and tax workflows through MCP.",
   "author": {
     "name": "Norman Finance",
     "email": "support@norman.finance"
@@ -11,12 +11,16 @@
   "license": "MIT",
   "keywords": [
     "finance",
+    "ai",
+    "automation",
     "bookkeeping",
     "accounting",
     "invoicing",
     "taxes",
-    "german",
+    "receipts",
+    "documents",
     "freelancer",
+    "ledger",
     "mcp",
     "oauth"
   ],

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
       <img width="140px" src="https://github.com/user-attachments/assets/d2cb1df3-69f1-460e-b675-beb677577b06" alt="Norman" />
    </a>
    <h1>Norman MCP Server</h1>
-   <p>AI-powered bookkeeping, accounting, and taxes, inside your AI assistant.<br/>
+   <p>AI-powered bookkeeping, accounting, and taxes for European businesses, inside your AI assistant.<br/>
    Norman connects invoicing, transactions, receipts, ledgers, reports, taxes, and company workflows to any MCP-compatible AI.</p>
    <br/>
    <p>
@@ -45,7 +45,7 @@
 
 **Documents** — Upload and attach receipts, invoices, and supporting files
 
-Norman is built as a multi-market accounting platform. Market-specific capabilities are added as Norman expands; current German coverage includes SKR03/SKR04, DATEV, ELSTER, ZUGFeRD, and GmbH/UG workflows.
+Norman is built as a multi-market European accounting platform. Market-specific capabilities are added as Norman expands; current German coverage includes SKR03/SKR04, DATEV, ELSTER, ZUGFeRD, and GmbH/UG workflows.
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
       <img width="140px" src="https://github.com/user-attachments/assets/d2cb1df3-69f1-460e-b675-beb677577b06" alt="Norman" />
    </a>
    <h1>Norman MCP Server</h1>
-   <p>Your finances, inside your AI assistant.<br/>
-   Norman connects your accounting, invoicing, and VAT filing directly to Claude, Cursor, and any MCP-compatible AI.</p>
+   <p>AI-powered bookkeeping, accounting, and taxes, inside your AI assistant.<br/>
+   Norman connects invoicing, transactions, receipts, ledgers, reports, taxes, and company workflows to any MCP-compatible AI.</p>
    <br/>
    <p>
       <img src="https://img.shields.io/badge/Protocol-MCP-black?style=flat-square" alt="MCP" />
@@ -44,6 +44,8 @@
 **Company Formation** — Found a German **GmbH or UG**: collect the founders' data, check the name against the Handelsregister, generate the founding documents (Musterprotokoll, Gesellschafterliste), match with a notary, and track every step through to registration
 
 **Documents** — Upload and attach receipts, invoices, and supporting files
+
+Norman is built as a multi-market accounting platform. Market-specific capabilities are added as Norman expands; current German coverage includes SKR03/SKR04, DATEV, ELSTER, ZUGFeRD, and GmbH/UG workflows.
 
 <br/>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "norman-mcp-server"
 version = "0.1.7"
-description = "AI-powered bookkeeping, accounting, invoicing, and tax workflows via MCP"
+description = "AI-powered bookkeeping, accounting, invoicing, and tax workflows for European businesses via MCP"
 readme = "README.md"
 authors = [
     {name = "Norman Finance", email = "stan@norman.finance"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "norman-mcp-server"
 version = "0.1.7"
-description = "A Model Context Protocol (MCP) server for Norman Finance API"
+description = "AI-powered bookkeeping, accounting, invoicing, and tax workflows via MCP"
 readme = "README.md"
 authors = [
     {name = "Norman Finance", email = "stan@norman.finance"}

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "finance.norman/mcp-server",
   "title": "Norman Finance — AI Bookkeeping, Accounting & Taxes",
-  "description": "AI-powered bookkeeping and accounting via MCP: invoices, transactions, receipts, ledgers, reports, documents, taxes, and company workflows.",
+  "description": "AI-powered bookkeeping and accounting for European businesses via MCP: invoices, transactions, receipts, ledgers, reports, documents, taxes, and company workflows.",
   "icons": [
     {
       "src": "https://norman.finance/icon.png",

--- a/server.json
+++ b/server.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "finance.norman/mcp-server",
-  "title": "Norman Finance — Accounting, Bookkeeping & Taxes (Germany)",
-  "description": "AI accounting for German businesses: bookkeeping, invoices, receipts, VAT & tax filing via ELSTER.",
+  "title": "Norman Finance — AI Bookkeeping, Accounting & Taxes",
+  "description": "AI-powered bookkeeping and accounting via MCP: invoices, transactions, receipts, ledgers, reports, documents, taxes, and company workflows.",
   "icons": [
     {
       "src": "https://norman.finance/icon.png",


### PR DESCRIPTION
## Summary

- position Norman MCP around AI-powered bookkeeping, accounting, invoicing, and taxes for European businesses
- avoid presenting Germany as the product boundary
- keep Germany-specific integrations as current market coverage while leaving room for neighboring markets
- align the MCP Registry, PyPI, Claude, and Cursor metadata

## Scope

Documentation and public metadata only. This PR does not change MCP tools, document ingestion, file handling, client integrations, or runtime behavior.

## Verification

- validated all changed JSON manifests with `python -m json.tool`
- `git diff --check`