### PR TITLE
fix: deliver portable MCP app views reliably

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,37 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST }}
           username: root
           key: ${{ secrets.SSH_KEY }}
-          script: docker service update norman_mcp --image ghcr.io/${{ steps.image.outputs.lowercase }}/norman-mcp-server:${{ github.sha }} --with-registry-auth
+          script_stop: true
+          script: |
+            set -eu
+            service="norman_mcp"
+            image="ghcr.io/${{ steps.image.outputs.lowercase }}/norman-mcp-server:${{ github.sha }}"
+
+            diagnostics() {
+              docker service inspect "$service" --pretty || true
+              docker service ps "$service" --no-trunc || true
+              docker service logs "$service" --tail 200 || true
+            }
+
+            docker service update "$service" --image "$image" --with-registry-auth
+
+            state=$(docker service inspect "$service" --format '{{if .UpdateStatus}}{{.UpdateStatus.State}}{{else}}unknown{{end}}')
+            running_image=$(docker service inspect "$service" --format '{{.Spec.TaskTemplate.ContainerSpec.Image}}')
+
+            if [ "$state" != "completed" ]; then
+              echo "Deployment did not complete successfully: update state is $state" >&2
+              diagnostics
+              exit 1
+            fi
+
+            case "$running_image" in
+              "$image"|"$image"@*) ;;
+              *)
+                echo "Deployment image mismatch: expected $image, running $running_image" >&2
+                diagnostics
+                exit 1
+                ;;
+            esac
 
       - name: finalize sentry release
         uses: getsentry/action-release@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ COPY . /app/
 
 # Install the package and additional dependencies
 RUN pip install -e . && \
-    pip install fastapi uvicorn pydantic pdf2image pillow requests sentry-sdk
+    pip install fastapi uvicorn pydantic pdf2image pillow requests sentry-sdk && \
+    python -c "import norman_mcp.server"
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1

--- a/norman_mcp/apps/public.py
+++ b/norman_mcp/apps/public.py
@@ -19,7 +19,7 @@ from pydantic import Field
 from norman_mcp import config
 from norman_mcp.context import Context
 
-APP_RESOURCE_URI = "ui://norman/accounting-workbench-v1.html"
+APP_RESOURCE_URI = "ui://norman/accounting-workbench-v2.html"
 APP_MIME_TYPE = "text/html;profile=mcp-app"
 
 READ_ONLY = ToolAnnotations(
@@ -206,7 +206,12 @@ def _render_result(view: str, title: str, payload: Dict[str, Any]) -> CallToolRe
         content=[
             TextContent(
                 type="text",
-                text=f"Opened {title} with {count} visible row{'s' if count != 1 else ''}.",
+                text=(
+                    f"{title} data is ready with {count} visible "
+                    f"row{'s' if count != 1 else ''}. Compatible clients render the attached "
+                    "interactive view; do not claim that a screen opened unless the client "
+                    "actually displayed it."
+                ),
             )
         ],
         structuredContent=data,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,9 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "mcp[cli]>=1.8.0",
+    # FastMCP was removed in MCP 2.x. Keep the hosted image on the API this
+    # server currently implements until the v2 migration is complete.
+    "mcp[cli]>=1.8.0,<2",
     "requests>=2.25.0",
     "python-dotenv>=0.19.0",
     "pyyaml>=6.0.1",

--- a/tests/test_public_apps.py
+++ b/tests/test_public_apps.py
@@ -5,6 +5,8 @@ from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any
 
+from mcp.server.fastmcp import FastMCP
+from mcp.shared.memory import create_connected_server_and_client_session
 from mcp.types import CallToolResult
 
 from norman_mcp.apps.public import (
@@ -231,3 +233,41 @@ def test_render_tools_return_structured_content_and_widget_only_meta() -> None:
     assert isinstance(result, CallToolResult)
     assert result.structuredContent["view"] == "documents"
     assert result.meta == {"norman/view": "documents"}
+    assert "data is ready" in result.content[0].text
+    assert "Opened" not in result.content[0].text
+
+
+def test_app_contract_survives_real_mcp_protocol_serialization() -> None:
+    async def exercise_protocol() -> None:
+        mcp = FastMCP("public-app-contract")
+        register_public_apps(mcp)
+
+        async with create_connected_server_and_client_session(
+            mcp, raise_exceptions=True
+        ) as session:
+            tools = await session.list_tools()
+            render_tools = {
+                tool.name: tool for tool in tools.tools if tool.name.startswith("render_")
+            }
+            assert set(render_tools) == {
+                "render_document_review",
+                "render_reconciliation_cockpit",
+                "render_ledger_explorer",
+            }
+            for tool in render_tools.values():
+                assert tool.meta["ui"]["resourceUri"] == APP_RESOURCE_URI
+                assert tool.meta["openai/outputTemplate"] == APP_RESOURCE_URI
+
+            resources = await session.list_resources()
+            app_resource = next(
+                resource
+                for resource in resources.resources
+                if str(resource.uri) == APP_RESOURCE_URI
+            )
+            assert app_resource.mimeType == APP_MIME_TYPE
+
+            content = await session.read_resource(APP_RESOURCE_URI)
+            assert content.contents[0].mimeType == APP_MIME_TYPE
+            assert "ui/notifications/tool-result" in content.contents[0].text
+
+    asyncio.run(exercise_protocol())

--- a/uv.lock
+++ b/uv.lock
@@ -638,6 +638,9 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
 ]
+sentry = [
+    { name = "sentry-sdk" },
+]
 sse = [
     { name = "fastapi" },
     { name = "pydantic" },
@@ -652,16 +655,17 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.24.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.10.1" },
     { name = "jinja2", specifier = ">=3.0.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.8.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.8.0,<2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=0.942" },
     { name = "pydantic", marker = "extra == 'sse'", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "python-dotenv", specifier = ">=0.19.0" },
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "requests", specifier = ">=2.25.0" },
+    { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = ">=2.0.0" },
     { name = "uvicorn", marker = "extra == 'sse'", specifier = ">=0.22.0" },
 ]
-provides-extras = ["dev", "sse"]
+provides-extras = ["dev", "sse", "sentry"]
 
 [[package]]
 name = "packaging"
@@ -1129,6 +1133,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981 },
     { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782 },
     { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191 },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.68.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/e7/c504a4bd2d95df2e0ab73714a9161ff1cf6ff1486922685e5f46dfd9eba8/sentry_sdk-2.68.1.tar.gz", hash = "sha256:6a97895230b04bc35d4d8d2e51e3b9e21902dfb0086ccf1f131a80c15c7b997a", size = 1019262 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/28/465ad9382be98f2172e691f5836cf87f936773913ad7ab85ba1ba1d6706e/sentry_sdk-2.68.1-py3-none-any.whl", hash = "sha256:775b78871783a0ffd758276ad01b3bb2b1ebcdad8f9d2f0a7723f76b73c99b65", size = 520851 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- keep the hosted server on MCP 1.x until its FastMCP integration is migrated to MCP 2.x
- fail Docker image builds when the server cannot import, and fail deployment when Swarm rolls back or keeps the previous image
- stop claiming an interactive screen opened when a host did not render it; bump the MCP App resource URI to v2 to invalidate stale caches
- verify the app resource, MIME type, and render-tool metadata through a real MCP protocol session

## Root cause
The production image resolved MCP 2.x, where FastMCP is no longer available. The container exited during import. Docker Swarm rolled the service back, while the workflow still completed successfully because it did not inspect UpdateStatus after docker service update.

## Verification
- uv run --locked --extra dev pytest -q tests/test_public_apps.py (6 passed)
- uv run --extra dev pytest -q --ignore=tests/test_basic.py (82 passed, 3 skipped)
- production Docker image builds successfully with the import smoke check
- built container starts successfully; /mcp returns the expected OAuth 401 when unauthenticated
- workflow YAML and remote shell syntax validated

## Production probe before this fix
A direct authenticated MCP session against https://mcp.norman.finance/mcp reported 104 tools and 4 resources, but none of the six interactive accounting tools or ui://norman/accounting-workbench-v1.html were present, confirming the interactive-app deployment had not reached production.

## Known baseline
The complete test suite still stops during collection in tests/test_basic.py because it imports Config from norman_mcp.server; this predates and is unrelated to this change.