### PR TITLE
fix: preserve compound MCP deploy script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,6 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST }}
           username: root
           key: ${{ secrets.SSH_KEY }}
-          script_stop: true
           script: |
             set -eu
             service="norman_mcp"


### PR DESCRIPTION
## Summary
- remove `script_stop` from the legacy SSH action because it injects commands after every source line and corrupts `case`/`while` compound syntax
- retain fail-fast behavior through the script's existing `set -eu`

## Evidence
The production task reached `Service converged`, then the rewritten remote script failed with `syntax error near unexpected token ;;`.

## Verification
- workflow YAML parses successfully
- confirmed `script_stop` is absent from the deploy action inputs
- extracted deploy script passes both `sh -n` and `bash -n`
- `git diff --check` passes