### PR TITLE
feat: add Norman-style accounting and tax MCP apps

### DIFF
--- a/norman_mcp/apps/accounting_workbench.html
+++ b/norman_mcp/apps/accounting_workbench.html
@@ -5,46 +5,58 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Norman Accounting Workbench</title>
   <style>
-    :root { color-scheme: light dark; --ink:#171717; --muted:#6b6b6b; --line:#e7e7e5; --panel:#f7f7f5; --accent:#111; --bad:#9b2c2c; --warn:#8a5a00; --good:#17643b; --surface:#fff; }
-    @media (prefers-color-scheme:dark) { :root { --ink:#f5f5f2; --muted:#aaa; --line:#363634; --panel:#222220; --accent:#fff; --bad:#ff9a9a; --warn:#ffc565; --good:#7ee2a8; --surface:#171716; } }
+    :root { color-scheme:light dark; --ink:#171717; --muted:#6d6d6d; --line:#dededc; --panel:#f7f7f5; --accent:#111; --bad:#9b2c2c; --warn:#8a5a00; --good:#17643b; --surface:#fff; }
+    @media (prefers-color-scheme:dark) { :root { --ink:#f5f5f2; --muted:#aaa; --line:#3b3b38; --panel:#222220; --accent:#fff; --bad:#ff9a9a; --warn:#ffc565; --good:#7ee2a8; --surface:#171716; } }
     * { box-sizing:border-box; }
-    body { margin:0; background:var(--surface); color:var(--ink); font:14px/1.45 ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
-    button,input,select { font:inherit; }
+    html,body { margin:0; min-width:0; width:100%; }
+    body { background:var(--surface); color:var(--ink); font:14px/1.5 "Plus Jakarta Sans",ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+    button,input,select { appearance:none; -webkit-appearance:none; border-radius:0; font:inherit; }
     button { color:inherit; }
-    .app { min-height:360px; padding:18px; }
+    button:focus-visible,input:focus-visible { outline:2px solid var(--ink); outline-offset:2px; }
+    .app { min-height:360px; min-width:0; overflow:hidden; padding:20px; }
     .top { display:flex; justify-content:space-between; align-items:flex-start; gap:16px; }
-    h1 { font-size:20px; line-height:1.2; margin:0; }
-    .eyebrow { color:var(--muted); font-size:11px; font-weight:700; letter-spacing:.09em; margin-bottom:5px; text-transform:uppercase; }
-    .tabs { display:flex; gap:4px; margin:16px 0; padding-bottom:10px; border-bottom:1px solid var(--line); overflow:auto; }
-    .tab,.filter,.ghost,.primary { border:1px solid transparent; background:transparent; border-radius:999px; cursor:pointer; padding:7px 11px; white-space:nowrap; }
-    .tab:hover,.filter:hover,.ghost:hover { background:var(--panel); }
-    .tab.active,.filter.active { border-color:var(--ink); }
-    .primary { border-radius:6px; background:var(--accent); color:var(--surface); font-weight:650; }
-    .ghost { border-color:var(--line); border-radius:6px; }
-    .summary { display:grid; grid-template-columns:repeat(auto-fit,minmax(115px,1fr)); gap:8px; margin-bottom:14px; }
-    .metric { background:var(--panel); border:1px solid var(--line); border-radius:8px; padding:10px 12px; }
-    .metric strong { display:block; font-size:19px; }
-    .metric span { color:var(--muted); font-size:12px; }
-    .toolbar { display:flex; flex-wrap:wrap; gap:8px; align-items:center; margin-bottom:12px; }
-    .toolbar input { min-width:180px; flex:1; border:1px solid var(--line); background:var(--surface); color:var(--ink); border-radius:6px; padding:8px 10px; }
-    .filters { display:flex; flex-wrap:wrap; gap:4px; }
-    .table-wrap { overflow:auto; border:1px solid var(--line); border-radius:8px; }
-    table { width:100%; border-collapse:collapse; min-width:650px; }
-    th { color:var(--muted); font-size:11px; letter-spacing:.04em; text-align:left; text-transform:uppercase; }
-    th,td { border-bottom:1px solid var(--line); padding:10px 12px; vertical-align:top; }
+    h1 { font-size:22px; font-weight:650; letter-spacing:-.02em; line-height:1.2; margin:0; }
+    .eyebrow { color:var(--muted); font-size:10px; font-weight:700; letter-spacing:.12em; margin-bottom:6px; text-transform:uppercase; }
+    .tabs { border-bottom:1px solid var(--line); display:flex; gap:24px; margin:22px 0 20px; overflow:auto; }
+    .tab,.filter,.ghost,.primary { background:transparent; border:0; cursor:pointer; white-space:nowrap; }
+    .tab { border-bottom:2px solid transparent; color:var(--muted); margin-bottom:-1px; padding:0 0 10px; }
+    .tab:hover,.tab.active { color:var(--ink); }
+    .tab.active { border-bottom-color:var(--ink); font-weight:650; }
+    .primary { background:var(--accent); border:1px solid var(--accent); color:var(--surface); font-weight:650; padding:9px 14px; }
+    .primary:hover { opacity:.82; }
+    .ghost { border:1px solid var(--line); padding:7px 10px; }
+    .ghost:hover { border-color:var(--ink); }
+    .summary { border:1px solid var(--line); display:grid; grid-template-columns:repeat(auto-fit,minmax(112px,1fr)); margin-bottom:18px; }
+    .metric { background:var(--surface); border-right:1px solid var(--line); min-width:0; padding:12px 14px; }
+    .metric:last-child { border-right:0; }
+    .metric strong { display:block; font-size:20px; font-weight:650; line-height:1.25; }
+    .metric span { color:var(--muted); display:block; font-size:11px; margin-top:3px; text-transform:capitalize; }
+    .toolbar { align-items:flex-end; display:flex; flex-wrap:wrap; gap:18px; margin-bottom:16px; }
+    .toolbar input { background:var(--surface); border:0; border-bottom:1px solid var(--line); color:var(--ink); flex:1; min-width:190px; padding:8px 2px; }
+    .toolbar input:focus { border-bottom-color:var(--ink); }
+    .filters { display:flex; flex-wrap:wrap; gap:18px; }
+    .filter { border-bottom:2px solid transparent; color:var(--muted); padding:8px 0 6px; }
+    .filter:hover,.filter.active { color:var(--ink); }
+    .filter.active { border-bottom-color:var(--ink); font-weight:650; }
+    .table-wrap { border:1px solid var(--line); max-width:100%; overflow:auto; scrollbar-gutter:stable; }
+    table { border-collapse:collapse; min-width:720px; width:100%; }
+    th { color:var(--muted); font-size:10px; font-weight:650; letter-spacing:.08em; text-align:left; text-transform:uppercase; }
+    th,td { border-bottom:1px solid var(--line); padding:13px 14px; vertical-align:top; }
     tr:last-child td { border-bottom:0; }
     tbody tr[data-selectable="true"] { cursor:pointer; }
     tbody tr[data-selectable="true"]:hover { background:var(--panel); }
     .num { font-variant-numeric:tabular-nums; text-align:right; white-space:nowrap; }
-    .badge { display:inline-block; border:1px solid var(--line); border-radius:999px; font-size:11px; margin:1px 3px 1px 0; padding:2px 7px; white-space:nowrap; }
+    .badge { display:inline-block; border:1px solid var(--line); font-size:10px; margin:1px 3px 1px 0; padding:2px 6px; white-space:nowrap; }
     .badge.bad { border-color:color-mix(in srgb,var(--bad) 45%,transparent); color:var(--bad); }
     .badge.warn { border-color:color-mix(in srgb,var(--warn) 45%,transparent); color:var(--warn); }
     .badge.good { border-color:color-mix(in srgb,var(--good) 45%,transparent); color:var(--good); }
     .muted { color:var(--muted); }
-    .empty,.error { border:1px dashed var(--line); border-radius:8px; color:var(--muted); padding:30px; text-align:center; }
+    .empty,.error { border:1px solid var(--line); color:var(--muted); padding:30px; text-align:center; }
     .error { border-color:var(--bad); color:var(--bad); }
-    .detail { display:grid; grid-template-columns:minmax(0,1fr) 260px; gap:14px; }
-    .inspector { background:var(--panel); border:1px solid var(--line); border-radius:8px; padding:14px; }
+    .detail { display:block; min-width:0; }
+    .detail > div { min-width:0; }
+    .detail.with-inspector { display:grid; gap:16px; grid-template-columns:minmax(0,1fr) 260px; }
+    .inspector { background:var(--panel); border:1px solid var(--line); padding:14px; }
     .inspector h2 { font-size:15px; margin:0 0 10px; }
     .kv { display:grid; grid-template-columns:90px 1fr; gap:6px 10px; margin-bottom:14px; }
     .kv dt { color:var(--muted); }
@@ -52,7 +64,7 @@
     .loading { align-items:center; background:color-mix(in srgb,var(--surface) 88%,transparent); display:none; inset:0; justify-content:center; position:absolute; z-index:3; }
     .loading.show { display:flex; }
     .shell { position:relative; }
-    @media (max-width:720px) { .app{padding:12px}.detail{grid-template-columns:1fr}.inspector{order:-1}.top{display:block}.primary{margin-top:10px} }
+    @media (max-width:720px) { .app{padding:14px}.detail.with-inspector{grid-template-columns:1fr}.inspector{order:-1}.top{display:block}.primary{margin-top:12px}.summary{grid-template-columns:repeat(2,minmax(0,1fr))}.metric:nth-child(even){border-right:0}.metric:nth-child(n+3){border-top:1px solid var(--line)}.tabs,.filters{gap:16px} }
   </style>
 </head>
 <body>
@@ -60,7 +72,7 @@
     <div id="loading" class="loading">Loading…</div>
     <div class="top">
       <div><div class="eyebrow">Norman Finance</div><h1 id="title">Accounting Workbench</h1></div>
-      <button id="ask" class="primary" type="button">Ask AI about this</button>
+      <button id="ask" class="primary" type="button">Ask AI</button>
     </div>
     <nav class="tabs" aria-label="Accounting views">
       <button class="tab" data-view="documents" type="button">Document Review</button>
@@ -139,7 +151,7 @@
         const selected=state.selected && (data.items||[]).find(item=>item.id===state.selected);
         const table=`<div class="table-wrap"><table><thead><tr><th>Document</th><th>Supplier</th><th>Date</th><th class="num">Amount</th><th>Status</th></tr></thead><tbody>${rows.map(item=>`<tr data-selectable="true" data-id="${esc(item.id)}"><td><strong>${esc(item.fileName||"Untitled")}</strong><br><span class="muted">${esc(item.type||"")}</span></td><td>${esc(item.brand||item.description||"—")}</td><td>${date(item.date)}</td><td class="num">${num(item.amount,item.currency)}</td><td><span class="badge ${item.linked?"good":"warn"}">${esc(item.status)}</span></td></tr>`).join("")}</tbody></table></div>`;
         const inspector=selected?`<aside class="inspector"><h2>${esc(selected.fileName)}</h2><dl class="kv"><dt>Supplier</dt><dd>${esc(selected.brand||"—")}</dd><dt>Number</dt><dd>${esc(selected.number||"—")}</dd><dt>VAT</dt><dd>${esc(selected.vatRate??"—")}%</dd><dt>Linked</dt><dd>${selected.linked?"Yes":"No"}</dd></dl><button class="ghost row-ask" data-kind="document" data-id="${esc(selected.id)}" type="button">Review in chat</button></aside>`:"";
-        return `${metrics(data.summary)}${toolbar([["all","All"],["unmatched","Needs match"],["linked","Linked"]])}<div class="detail"><div>${rows.length?table:'<div class="empty">No documents match this filter.</div>'}</div>${inspector}</div>`;
+        return `${metrics(data.summary)}${toolbar([["all","All"],["unmatched","Needs match"],["linked","Linked"]])}<div class="detail ${inspector?"with-inspector":""}"><div>${rows.length?table:'<div class="empty">No documents match this filter.</div>'}</div>${inspector}</div>`;
       }
       function reconciliationView(data) {
         const rows=(data.items||[]).filter(item => {

--- a/norman_mcp/apps/public.py
+++ b/norman_mcp/apps/public.py
@@ -1,10 +1,11 @@
-"""Read-only MCP Apps for Norman's public connector.
+"""Portable MCP Apps for Norman's public connector.
 
 The tools in this module deliberately reuse Norman's existing REST API.  The
 API remains authoritative; the embedded UI only presents compact, normalized
 read models.  Data tools stay useful in hosts without MCP Apps support, while
 the matching render tools progressively enhance the result in compatible
-hosts such as ChatGPT and Claude.
+hosts such as ChatGPT and Claude.  Binding actions remain explicit tool calls;
+the tax UI never submits while rendering or previewing a report.
 """
 
 from __future__ import annotations
@@ -20,6 +21,7 @@ from norman_mcp import config
 from norman_mcp.context import Context
 
 APP_RESOURCE_URI = "ui://norman/accounting-workbench-v3.html"
+TAX_APP_RESOURCE_URI = "ui://norman/tax-filing-v1.html"
 APP_MIME_TYPE = "text/html;profile=mcp-app"
 
 READ_ONLY = ToolAnnotations(
@@ -193,11 +195,103 @@ def _posting_row(item: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+_SUBMITTED_TAX_STATUSES = {"SUBMIT", "SUBMITTED", "FILED", "SUBMIT_AND_PAID"}
+
+
+def _tax_line_rows(report: Dict[str, Any], limit: int = 80) -> list[Dict[str, Any]]:
+    raw_lines = _first(report, "tax_lines", "taxLines", default={})
+    candidates: list[tuple[str, Any]] = []
+    if isinstance(raw_lines, dict):
+        line_items = _first(raw_lines, "lineItems", "line_items", default=None)
+        if isinstance(line_items, list):
+            candidates.extend((str(index + 1), item) for index, item in enumerate(line_items))
+        else:
+            candidates.extend((str(key), value) for key, value in raw_lines.items())
+    elif isinstance(raw_lines, list):
+        candidates.extend((str(index + 1), item) for index, item in enumerate(raw_lines))
+
+    rows: list[Dict[str, Any]] = []
+    for fallback_code, value in candidates:
+        if not isinstance(value, dict):
+            continue
+        category = _first(value, "category", default={})
+        category_name = _name(category)
+        code = str(
+            _first(
+                value,
+                "positionNumber",
+                "position_number",
+                "code",
+                default=fallback_code,
+            )
+        )
+        label = str(
+            _first(value, "description", "label", "name", default="")
+            or category_name
+            or fallback_code
+        )
+        rows.append(
+            {
+                "code": code,
+                "label": label,
+                "net": _first(value, "netAmount", "net_amount", default=None),
+                "tax": _first(
+                    value,
+                    "taxAmount",
+                    "tax_amount",
+                    "totalVatAmount",
+                    "total_vat_amount",
+                    default=None,
+                ),
+                "gross": _first(
+                    value,
+                    "grossAmount",
+                    "gross_amount",
+                    "amount",
+                    "value",
+                    default=None,
+                ),
+            }
+        )
+        if len(rows) >= limit:
+            break
+    return rows
+
+
+def _tax_report_data(report: Dict[str, Any]) -> Dict[str, Any]:
+    status = str(_first(report, "status", default=""))
+    return {
+        "id": str(_first(report, "pk", "public_id", "publicId", default="")),
+        "type": str(_first(report, "type", default="")),
+        "typeName": str(_first(report, "type_name", "typeName", default="Tax report")),
+        "referenceName": str(
+            _first(report, "reference_name", "referenceName", default="Tax report")
+        ),
+        "dateFrom": str(_first(report, "date_from", "dateFrom", default="")),
+        "dateTo": str(_first(report, "date_to", "dateTo", default="")),
+        "dateDue": str(_first(report, "date_due", "dateDue", default="")),
+        "submissionDate": str(
+            _first(report, "submission_date", "submissionDate", default="") or ""
+        ),
+        "status": status,
+        "statusName": str(_first(report, "status_name", "statusName", default=status or "Draft")),
+        "total": _first(report, "total", default="0"),
+        "currency": _currency(_first(report, "currency", default="EUR")),
+        "reportFile": str(_first(report, "report_file", "reportFile", default="") or ""),
+        "submitted": status.upper() in _SUBMITTED_TAX_STATUSES,
+    }
+
+
 def _error_view(view: str, title: str, error: Any) -> Dict[str, Any]:
     return {"view": view, "title": title, "error": str(error), "items": [], "summary": {}}
 
 
-def _render_result(view: str, title: str, payload: Dict[str, Any]) -> CallToolResult:
+def _render_result(
+    view: str,
+    title: str,
+    payload: Dict[str, Any],
+    widget_meta: Optional[Dict[str, Any]] = None,
+) -> CallToolResult:
     data = dict(payload)
     data["view"] = view
     data["title"] = title
@@ -215,21 +309,23 @@ def _render_result(view: str, title: str, payload: Dict[str, Any]) -> CallToolRe
             )
         ],
         structuredContent=data,
-        _meta={"norman/view": view},
+        _meta={"norman/view": view, **(widget_meta or {})},
     )
 
 
-def _render_meta(invoking: str, invoked: str) -> Dict[str, Any]:
+def _render_meta(
+    invoking: str, invoked: str, resource_uri: str = APP_RESOURCE_URI
+) -> Dict[str, Any]:
     return {
-        "ui": {"resourceUri": APP_RESOURCE_URI},
-        "openai/outputTemplate": APP_RESOURCE_URI,
+        "ui": {"resourceUri": resource_uri},
+        "openai/outputTemplate": resource_uri,
         "openai/toolInvocation/invoking": invoking,
         "openai/toolInvocation/invoked": invoked,
     }
 
 
 def register_public_apps(mcp: Any) -> None:
-    """Register the public connector's portable accounting workbench."""
+    """Register the public connector's portable accounting and tax views."""
 
     @mcp.resource(
         APP_RESOURCE_URI,
@@ -239,14 +335,14 @@ def register_public_apps(mcp: Any) -> None:
         mime_type=APP_MIME_TYPE,
         meta={
             "ui": {
-                "prefersBorder": True,
+                "prefersBorder": False,
                 "csp": {"connectDomains": [], "resourceDomains": []},
             },
             "openai/widgetDescription": (
                 "A read-only Norman accounting workbench for reviewing documents, "
                 "reconciliation issues and Ledger account postings."
             ),
-            "openai/widgetPrefersBorder": True,
+            "openai/widgetPrefersBorder": False,
             "openai/widgetCSP": {
                 "connect_domains": [],
                 "resource_domains": [],
@@ -255,6 +351,179 @@ def register_public_apps(mcp: Any) -> None:
     )
     async def accounting_workbench() -> str:
         return (Path(__file__).with_name("accounting_workbench.html")).read_text(encoding="utf-8")
+
+    @mcp.resource(
+        TAX_APP_RESOURCE_URI,
+        name="norman-tax-filing",
+        title="Norman Tax Filing",
+        description="Interactive Finanzamt preview and explicitly confirmed submission flow.",
+        mime_type=APP_MIME_TYPE,
+        meta={
+            "ui": {
+                "prefersBorder": False,
+                "csp": {"connectDomains": [], "resourceDomains": []},
+            },
+            "openai/widgetDescription": (
+                "A Norman tax filing view for reviewing a test Finanzamt preview and, "
+                "only after explicit user confirmation, submitting the selected report."
+            ),
+            "openai/widgetPrefersBorder": False,
+            "openai/widgetCSP": {"connect_domains": [], "resource_domains": []},
+        },
+    )
+    async def tax_filing() -> str:
+        return (Path(__file__).with_name("tax_filing.html")).read_text(encoding="utf-8")
+
+    async def load_tax_filing(
+        ctx: Context, report_id: str, *, generate_preview: bool
+    ) -> tuple[Dict[str, Any], Optional[str]]:
+        api, company_id, error = _api_and_company(ctx)
+        if error:
+            return _error_view("tax-filing", "Tax filing", error["error"]), None
+        report_id = str(report_id or "").strip()
+        if not report_id:
+            return _error_view("tax-filing", "Tax filing", "A report ID is required."), None
+
+        endpoint = f"taxes/reports/{report_id}/"
+        response = await api.arequest("GET", _company_url(company_id, endpoint))
+        if not isinstance(response, dict) or response.get("error"):
+            message = (
+                response.get("error") if isinstance(response, dict) else "Invalid report response"
+            )
+            return _error_view("tax-filing", "Tax filing", message), None
+
+        report = _tax_report_data(response)
+        rows = _tax_line_rows(response)
+        preview: Dict[str, Any] = {
+            "available": False,
+            "mimeType": "image/jpeg",
+            "downloadUrl": "",
+            "error": "",
+        }
+        preview_image: Optional[str] = None
+
+        if generate_preview and not report["submitted"]:
+            preview_response = await api.arequest(
+                "POST",
+                _company_url(company_id, f"taxes/reports/{report_id}/generate-preview-url/"),
+            )
+            if isinstance(preview_response, dict) and not preview_response.get("error"):
+                preview_image = str(preview_response.get("previewImage") or "") or None
+                preview.update(
+                    {
+                        "available": bool(preview_response.get("downloadUrl") and preview_image),
+                        "mimeType": str(preview_response.get("mimeType") or "image/jpeg"),
+                        "downloadUrl": str(preview_response.get("downloadUrl") or ""),
+                    }
+                )
+                if not preview["available"]:
+                    preview["error"] = "The preview service returned incomplete data."
+            else:
+                preview["error"] = str(
+                    preview_response.get("error", "Preview generation failed")
+                    if isinstance(preview_response, dict)
+                    else "Preview generation failed"
+                )
+
+        submitted_download_url = ""
+        if report["submitted"] and report["reportFile"]:
+            download_response = await api.arequest(
+                "GET",
+                _company_url(company_id, f"taxes/reports/{report_id}/download/"),
+            )
+            if isinstance(download_response, dict):
+                submitted_download_url = str(download_response.get("url") or "")
+
+        can_submit = bool(preview["available"] and not report["submitted"])
+        data = {
+            "view": "tax-filing",
+            "title": "Tax filing",
+            "section": "preview",
+            "report": report,
+            "preview": preview,
+            "submittedDownloadUrl": submitted_download_url,
+            "items": rows,
+            "summary": {"lines": len(rows)},
+            "canSubmit": can_submit,
+            "checks": [
+                {"label": "Tax report loaded", "complete": True},
+                {"label": "Test preview generated", "complete": bool(preview["available"])},
+                {"label": "Not previously submitted", "complete": not report["submitted"]},
+            ],
+        }
+        return data, preview_image
+
+    @mcp.tool(title="Get Tax Filing Data", annotations=READ_ONLY)
+    async def get_tax_filing_data(
+        ctx: Context,
+        report_id: str = Field(description="Public ID of the tax report to review"),
+    ) -> Dict[str, Any]:
+        """Get a compact test-preview and submission-readiness view for one tax report."""
+        data, _preview_image = await load_tax_filing(ctx, report_id, generate_preview=True)
+        return data
+
+    @mcp.tool(title="Get Tax Submission Status Data", annotations=READ_ONLY)
+    async def get_tax_submission_status_data(
+        ctx: Context,
+        report_id: str = Field(description="Public ID of the tax report to refresh"),
+    ) -> Dict[str, Any]:
+        """Refresh filing status after a submission attempt without creating a new preview."""
+        data, _preview_image = await load_tax_filing(ctx, report_id, generate_preview=False)
+        data["section"] = "submission"
+        return data
+
+    @mcp.tool(
+        title="Render Tax Preview",
+        description=(
+            "Open a test Finanzamt preview for a tax report. This never submits the report. "
+            "Call this directly with the report ID."
+        ),
+        annotations=READ_ONLY,
+        meta=_render_meta(
+            "Generating Finanzamt preview…",
+            "Tax preview ready",
+            TAX_APP_RESOURCE_URI,
+        ),
+    )
+    async def render_tax_preview(
+        ctx: Context,
+        report_id: str = Field(description="Public ID of the tax report to preview"),
+    ) -> CallToolResult:
+        data, preview_image = await load_tax_filing(ctx, report_id, generate_preview=True)
+        data["section"] = "preview"
+        return _render_result(
+            "tax-filing",
+            "Tax filing",
+            data,
+            {"norman/previewImage": preview_image} if preview_image else None,
+        )
+
+    @mcp.tool(
+        title="Render Tax Submission",
+        description=(
+            "Open the confirmation step for a tax report. Rendering never submits anything. "
+            "The user must review the generated test preview, check the explicit confirmation "
+            "box and invoke the destructive submission tool from the UI."
+        ),
+        annotations=READ_ONLY,
+        meta=_render_meta(
+            "Preparing tax submission review…",
+            "Submission review ready",
+            TAX_APP_RESOURCE_URI,
+        ),
+    )
+    async def render_tax_submission(
+        ctx: Context,
+        report_id: str = Field(description="Public ID of the tax report to review for submission"),
+    ) -> CallToolResult:
+        data, preview_image = await load_tax_filing(ctx, report_id, generate_preview=True)
+        data["section"] = "submission"
+        return _render_result(
+            "tax-filing",
+            "Tax filing",
+            data,
+            {"norman/previewImage": preview_image} if preview_image else None,
+        )
 
     @mcp.tool(title="Get Document Review Data", annotations=READ_ONLY)
     async def get_document_review_data(

--- a/norman_mcp/apps/public.py
+++ b/norman_mcp/apps/public.py
@@ -19,7 +19,7 @@ from pydantic import Field
 from norman_mcp import config
 from norman_mcp.context import Context
 
-APP_RESOURCE_URI = "ui://norman/accounting-workbench-v2.html"
+APP_RESOURCE_URI = "ui://norman/accounting-workbench-v3.html"
 APP_MIME_TYPE = "text/html;profile=mcp-app"
 
 READ_ONLY = ToolAnnotations(

--- a/norman_mcp/apps/tax_filing.html
+++ b/norman_mcp/apps/tax_filing.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Norman Tax Filing</title>
+  <style>
+    :root { color-scheme:light dark; --ink:#171717; --muted:#6d6d6d; --line:#dededc; --panel:#f7f7f5; --accent:#111; --bad:#9b2c2c; --warn:#8a5a00; --good:#17643b; --surface:#fff; }
+    @media (prefers-color-scheme:dark) { :root { --ink:#f5f5f2; --muted:#aaa; --line:#3b3b38; --panel:#222220; --accent:#fff; --bad:#ff9a9a; --warn:#ffc565; --good:#7ee2a8; --surface:#171716; } }
+    * { box-sizing:border-box; }
+    html,body { margin:0; min-width:0; width:100%; }
+    body { background:var(--surface); color:var(--ink); font:14px/1.5 "Plus Jakarta Sans",ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+    button,input { appearance:none; -webkit-appearance:none; border-radius:0; font:inherit; }
+    button { color:inherit; }
+    button:focus-visible,input:focus-visible { outline:2px solid var(--ink); outline-offset:2px; }
+    .app { min-height:420px; min-width:0; overflow:hidden; padding:20px; position:relative; }
+    .top { align-items:flex-start; display:flex; gap:16px; justify-content:space-between; }
+    h1 { font-size:22px; font-weight:650; letter-spacing:-.02em; line-height:1.2; margin:0; }
+    h2 { font-size:16px; font-weight:650; margin:0; }
+    .eyebrow { color:var(--muted); font-size:10px; font-weight:700; letter-spacing:.12em; margin-bottom:6px; text-transform:uppercase; }
+    .primary,.ghost,.tab { background:transparent; border:0; cursor:pointer; white-space:nowrap; }
+    .primary { background:var(--accent); border:1px solid var(--accent); color:var(--surface); font-weight:650; padding:9px 14px; }
+    .primary:hover { opacity:.82; }
+    .primary:disabled { background:var(--line); border-color:var(--line); color:var(--muted); cursor:not-allowed; opacity:1; }
+    .ghost { border:1px solid var(--line); padding:8px 12px; }
+    .ghost:hover { border-color:var(--ink); }
+    .tabs { border-bottom:1px solid var(--line); display:flex; gap:24px; margin:22px 0 20px; overflow:auto; }
+    .tab { border-bottom:2px solid transparent; color:var(--muted); margin-bottom:-1px; padding:0 0 10px; }
+    .tab:hover,.tab.active { color:var(--ink); }
+    .tab.active { border-bottom-color:var(--ink); font-weight:650; }
+    .overview { border:1px solid var(--line); display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); margin-bottom:18px; }
+    .metric { border-right:1px solid var(--line); min-width:0; padding:12px 14px; }
+    .metric:last-child { border-right:0; }
+    .metric strong { display:block; font-size:17px; font-weight:650; line-height:1.3; overflow-wrap:anywhere; }
+    .metric span { color:var(--muted); display:block; font-size:10px; letter-spacing:.05em; margin-top:3px; text-transform:uppercase; }
+    .notice { border:1px solid var(--line); margin-bottom:18px; padding:12px 14px; }
+    .notice strong { display:block; margin-bottom:2px; }
+    .notice.warn { border-left:3px solid var(--warn); }
+    .notice.good { border-left:3px solid var(--good); }
+    .notice.bad { border-left:3px solid var(--bad); color:var(--bad); }
+    .preview-grid { display:grid; gap:18px; grid-template-columns:minmax(0,1fr); }
+    .section-head { align-items:center; display:flex; gap:12px; justify-content:space-between; margin-bottom:12px; }
+    .paper { align-items:flex-start; background:var(--panel); border:1px solid var(--line); display:flex; justify-content:center; min-height:360px; overflow:auto; padding:16px; }
+    .paper img { background:#fff; box-shadow:0 1px 4px rgb(0 0 0 / 14%); display:block; height:auto; max-width:min(100%,620px); }
+    .placeholder { align-self:center; color:var(--muted); max-width:340px; text-align:center; }
+    .table-wrap { border:1px solid var(--line); max-width:100%; overflow:auto; }
+    table { border-collapse:collapse; min-width:420px; width:100%; }
+    th { color:var(--muted); font-size:10px; font-weight:650; letter-spacing:.08em; text-align:left; text-transform:uppercase; }
+    th,td { border-bottom:1px solid var(--line); padding:11px 12px; vertical-align:top; }
+    tr:last-child td { border-bottom:0; }
+    .num { font-variant-numeric:tabular-nums; text-align:right; white-space:nowrap; }
+    .submission-grid { display:grid; gap:18px; grid-template-columns:minmax(0,1fr) minmax(280px,.55fr); }
+    .checks { border:1px solid var(--line); }
+    .check { align-items:center; border-bottom:1px solid var(--line); display:flex; gap:10px; padding:13px 14px; }
+    .check:last-child { border-bottom:0; }
+    .mark { align-items:center; border:1px solid var(--line); display:inline-flex; flex:0 0 18px; height:18px; justify-content:center; width:18px; }
+    .check.complete .mark { background:var(--ink); border-color:var(--ink); color:var(--surface); }
+    .check.complete .mark::after { content:"✓"; font-size:11px; font-weight:700; }
+    .confirm-panel { background:var(--panel); border:1px solid var(--line); padding:16px; }
+    .confirm { align-items:flex-start; cursor:pointer; display:flex; gap:10px; margin:16px 0; }
+    .confirm input { background:var(--surface); border:1px solid var(--ink); flex:0 0 18px; height:18px; margin:2px 0 0; width:18px; }
+    .confirm input:checked { background:var(--ink); box-shadow:inset 0 0 0 4px var(--surface); }
+    .confirm-panel .primary { width:100%; }
+    .muted { color:var(--muted); }
+    .status { font-size:12px; margin-top:10px; min-height:18px; }
+    .status.bad { color:var(--bad); }
+    .loading { align-items:center; background:color-mix(in srgb,var(--surface) 88%,transparent); display:none; inset:0; justify-content:center; position:absolute; z-index:3; }
+    .loading.show { display:flex; }
+    @media (max-width:760px) { .app{padding:14px}.top{display:block}.top .primary{margin-top:12px}.overview{grid-template-columns:repeat(2,minmax(0,1fr))}.metric:nth-child(even){border-right:0}.metric:nth-child(n+3){border-top:1px solid var(--line)}.submission-grid{grid-template-columns:1fr}.tabs{gap:18px} }
+  </style>
+</head>
+<body>
+  <main class="app">
+    <div id="loading" class="loading">Working…</div>
+    <div class="top">
+      <div><div class="eyebrow">Norman Finance</div><h1 id="title">Tax filing</h1></div>
+      <button id="ask" class="primary" type="button">Ask AI</button>
+    </div>
+    <nav class="tabs" aria-label="Tax filing steps">
+      <button class="tab" data-section="preview" type="button">1. Preview</button>
+      <button class="tab" data-section="submission" type="button">2. Submission</button>
+    </nav>
+    <section id="content" aria-live="polite"><div class="notice">Waiting for Norman tax data…</div></section>
+  </main>
+  <script>
+    (() => {
+      const state={data:null,section:"preview",confirmed:false,previewImage:"",pending:new Map(),requestId:1,bridgeReady:false};
+      const title=document.getElementById("title");
+      const content=document.getElementById("content");
+      const loading=document.getElementById("loading");
+      const esc=value=>String(value??"").replace(/[&<>"']/g,char=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"})[char]);
+      const date=value=>value?esc(String(value).slice(0,10)):"—";
+      const money=(value,currency="EUR")=>{const parsed=Number(value??0);try{return new Intl.NumberFormat(document.documentElement.lang||"en",{style:"currency",currency:currency||"EUR"}).format(Number.isFinite(parsed)?parsed:0)}catch{return `${Number.isFinite(parsed)?parsed.toFixed(2):value} ${currency||""}`.trim()}};
+      const getStructured=result=>{if(result?.structuredContent)return result.structuredContent;const text=result?.content?.find?.(item=>item.type==="text")?.text;if(text){try{return JSON.parse(text)}catch{}}return result};
+      function request(method,params,timeout=12000){const id=state.requestId++;window.parent.postMessage({jsonrpc:"2.0",id,method,params},"*");return new Promise((resolve,reject)=>{const timer=setTimeout(()=>{state.pending.delete(id);reject(new Error("Host request timed out"))},timeout);state.pending.set(id,{resolve,reject,timer})})}
+      async function initializeApp(){try{await request("ui/initialize",{protocolVersion:"2026-01-26",appInfo:{name:"Norman Tax Filing",version:"1.0.0"},appCapabilities:{availableDisplayModes:["inline"]}},5000);state.bridgeReady=true;window.parent.postMessage({jsonrpc:"2.0",method:"ui/notifications/initialized",params:{}},"*")}catch{}}
+      async function callTool(name,args={}){if(state.bridgeReady||!window.openai?.callTool)return request("tools/call",{name,arguments:args});return window.openai.callTool(name,args)}
+      async function sendMessage(prompt){if(state.bridgeReady||!window.openai?.sendFollowUpMessage)return request("ui/message",{role:"user",content:[{type:"text",text:prompt}]},5000);return window.openai.sendFollowUpMessage({prompt})}
+      async function openLink(url){if(!url)return;if(state.bridgeReady)return request("ui/open-link",{url},5000);if(window.openai?.openExternal)return window.openai.openExternal({href:url});window.open(url,"_blank","noopener,noreferrer")}
+      function showLoading(show){loading.classList.toggle("show",show)}
+      function mergeToolData(data,meta={}){if(!data||typeof data!=="object")return;state.data=data;state.section=data.section||state.section;const image=meta?.["norman/previewImage"]||data.previewImage;if(image)state.previewImage=image;render()}
+      function overview(report={}){const period=report.dateFrom&&report.dateTo?`${date(report.dateFrom)} – ${date(report.dateTo)}`:"—";return `<div class="overview"><div class="metric"><strong>${esc(report.typeName||report.type||"Tax report")}</strong><span>Report</span></div><div class="metric"><strong>${period}</strong><span>Period</span></div><div class="metric"><strong>${date(report.dateDue)}</strong><span>Due date</span></div><div class="metric"><strong>${money(report.total,report.currency)}</strong><span>Total</span></div></div>`}
+      function imageSource(){if(!state.previewImage)return "";if(state.previewImage.startsWith("data:"))return state.previewImage;return `data:${state.data?.preview?.mimeType||"image/jpeg"};base64,${state.previewImage}`}
+      function lineTable(){const rows=state.data?.items||[];if(!rows.length)return '<div class="notice">No detailed tax lines were returned for this report.</div>';return `<div class="table-wrap"><table><thead><tr><th>Line</th><th>Description</th><th class="num">Net</th><th class="num">VAT</th><th class="num">Gross</th></tr></thead><tbody>${rows.map(row=>`<tr><td>${esc(row.code)}</td><td>${esc(row.label)}</td><td class="num">${row.net==null?"—":money(row.net,state.data.report.currency)}</td><td class="num">${row.tax==null?"—":money(row.tax,state.data.report.currency)}</td><td class="num">${row.gross==null?"—":money(row.gross,state.data.report.currency)}</td></tr>`).join("")}</tbody></table></div>`}
+      function previewView(){const data=state.data,report=data.report||{},preview=data.preview||{};if(report.submitted){return `<div class="notice good"><strong>Already submitted</strong>This report was filed${report.submissionDate?` on ${date(report.submissionDate)}`:""}. The submitted document is the authoritative copy.</div>${data.submittedDownloadUrl?`<button class="ghost open-link" data-url="${esc(data.submittedDownloadUrl)}" type="button">Download submitted PDF</button>`:""}`};const src=imageSource();return `<div class="notice"><strong>Test preview</strong>This preview uses ELSTER test mode and does not submit anything to the Finanzamt.</div>${preview.error?`<div class="notice bad">${esc(preview.error)}</div>`:""}<div class="preview-grid"><div><div class="section-head"><h2>Finanzamt preview</h2>${preview.downloadUrl?`<button class="ghost open-link" data-url="${esc(preview.downloadUrl)}" type="button">Download PDF</button>`:""}</div><div class="paper">${src?`<img src="${esc(src)}" alt="First page of the Finanzamt test preview">`:'<div class="placeholder">Preview image is unavailable. Resolve the reported issue before continuing to submission.</div>'}</div></div><aside><div class="section-head"><h2>Tax lines</h2></div>${lineTable()}</aside></div>`}
+      function submissionView(){const data=state.data,report=data.report||{};if(report.submitted){return `<div class="notice good"><strong>Submission completed</strong>${esc(report.statusName||"Filed")}${report.submissionDate?` · ${date(report.submissionDate)}`:""}</div>${data.submittedDownloadUrl?`<button class="ghost open-link" data-url="${esc(data.submittedDownloadUrl)}" type="button">Download submitted PDF</button>`:""}`};const checks=(data.checks||[]).map(check=>`<div class="check ${check.complete?"complete":""}"><span class="mark" aria-hidden="true"></span><span>${esc(check.label)}</span></div>`).join("");return `<div class="notice warn"><strong>Binding submission</strong>Submitting sends this report to the Finanzamt. It cannot be undone from Norman.</div><div class="submission-grid"><div><div class="section-head"><h2>Readiness</h2></div><div class="checks">${checks}</div></div><aside class="confirm-panel"><h2>Confirm submission</h2><p class="muted">Open and review the complete test PDF before continuing. Norman is a calculation tool; you remain responsible for the filing.</p><label class="confirm"><input id="confirm" type="checkbox" ${state.confirmed?"checked":""} ${data.canSubmit?"":"disabled"}><span>I reviewed the Finanzamt preview and confirm that this report should be submitted.</span></label><button id="submit" class="primary" type="button" ${data.canSubmit&&state.confirmed?"":"disabled"}>Submit to Finanzamt</button><div id="action-status" class="status ${data.canSubmit?"":"bad"}">${data.canSubmit?"A separate host confirmation may be shown.":"A valid test preview is required before submission."}</div></aside></div>`}
+      function render(){const data=state.data;if(!data||typeof data!=="object")return;title.textContent=data.report?.referenceName||data.title||"Tax filing";document.querySelectorAll(".tab").forEach(tab=>tab.classList.toggle("active",tab.dataset.section===state.section));if(data.error)content.innerHTML=`<div class="notice bad">${esc(data.error)}</div>`;else content.innerHTML=`${overview(data.report)}${state.section==="submission"?submissionView():previewView()}`;bind()}
+      function bind(){document.querySelectorAll(".open-link").forEach(button=>button.addEventListener("click",()=>openLink(button.dataset.url)));document.getElementById("confirm")?.addEventListener("change",event=>{state.confirmed=event.target.checked;render()});document.getElementById("submit")?.addEventListener("click",submitReport)}
+      async function submitReport(){const reportId=state.data?.report?.id;if(!reportId||!state.confirmed||!state.data?.canSubmit)return;showLoading(true);try{const result=await callTool("submit_tax_report",{report_id:reportId});const raw=getStructured(result);if(result?.isError||raw?.error)throw new Error(raw?.message||raw?.error||"Submission failed");const refreshed=await callTool("get_tax_submission_status_data",{report_id:reportId});const refreshedData=getStructured(refreshed);state.confirmed=false;mergeToolData({...state.data,...refreshedData,section:"submission"},refreshed?._meta||{});const status=document.getElementById("action-status");if(status&&!refreshedData?.report?.submitted)status.textContent="Submission was accepted; final status is still updating."}catch(error){const status=document.getElementById("action-status");if(status){status.classList.add("bad");status.textContent=error?.message||String(error)}}finally{showLoading(false)}}
+      document.querySelectorAll(".tab").forEach(tab=>tab.addEventListener("click",()=>{state.section=tab.dataset.section;render()}));
+      document.getElementById("ask").addEventListener("click",()=>sendMessage(`Review Norman tax report ${state.data?.report?.id||""}. Explain the figures, blockers and next safe step. Do not submit or change anything without my explicit confirmation.`));
+      window.addEventListener("message",event=>{if(event.source!==window.parent)return;const message=event.data;if(!message||message.jsonrpc!=="2.0")return;if(message.id!==undefined&&state.pending.has(message.id)){const pending=state.pending.get(message.id);state.pending.delete(message.id);clearTimeout(pending.timer);message.error?pending.reject(message.error):pending.resolve(message.result);return}if(message.method==="ui/notifications/tool-result")mergeToolData(message.params?.structuredContent,message.params?._meta||{})},{passive:true});
+      initializeApp();
+      if(window.openai?.toolOutput)mergeToolData(window.openai.toolOutput,window.openai.toolResponseMetadata||{});
+    })();
+  </script>
+</body>
+</html>

--- a/tests/test_public_apps.py
+++ b/tests/test_public_apps.py
@@ -12,6 +12,7 @@ from mcp.types import CallToolResult
 from norman_mcp.apps.public import (
     APP_MIME_TYPE,
     APP_RESOURCE_URI,
+    TAX_APP_RESOURCE_URI,
     register_public_apps,
 )
 
@@ -52,6 +53,37 @@ class FakeApi:
 
     async def arequest(self, method: str, url: str, **kwargs: Any) -> dict[str, Any]:
         self.requests.append((method, url, kwargs))
+        if url.endswith("/taxes/reports/report-1/generate-preview-url/"):
+            return {
+                "downloadUrl": "https://api.norman.finance/previews/report-1.pdf",
+                "previewImage": "dGVzdC1wcmV2aWV3",
+                "mimeType": "image/jpeg",
+            }
+        if url.endswith("/taxes/reports/report-1/"):
+            return {
+                "pk": "report-1",
+                "type": "ADVANCE_SALEX_TAX",
+                "type_name": "Advance VAT return",
+                "reference_name": "UStVA July 2026",
+                "date_from": "2026-07-01",
+                "date_to": "2026-07-31",
+                "date_due": "2026-08-10",
+                "submission_date": None,
+                "status": "DRAFT",
+                "status_name": "Draft",
+                "total": "119.00",
+                "currency": "EUR",
+                "report_file": None,
+                "tax_lines": {
+                    "81": {
+                        "positionNumber": "81",
+                        "description": "Taxable sales",
+                        "netAmount": "100.00",
+                        "taxAmount": "19.00",
+                        "grossAmount": "119.00",
+                    }
+                },
+            }
         if url.endswith("/attachments/"):
             return {
                 "results": [
@@ -127,10 +159,17 @@ def test_registers_portable_resource_and_decoupled_tools() -> None:
     mcp, _api = _registered()
 
     assert APP_RESOURCE_URI in mcp.resources
+    assert TAX_APP_RESOURCE_URI in mcp.resources
     assert mcp.resource_options[APP_RESOURCE_URI]["mime_type"] == APP_MIME_TYPE
+    assert mcp.resource_options[TAX_APP_RESOURCE_URI]["mime_type"] == APP_MIME_TYPE
     assert mcp.resource_options[APP_RESOURCE_URI]["meta"]["ui"]["csp"] == {
         "connectDomains": [],
         "resourceDomains": [],
+    }
+    assert mcp.resource_options[APP_RESOURCE_URI]["meta"]["ui"]["prefersBorder"] is False
+    assert mcp.resource_options[TAX_APP_RESOURCE_URI]["meta"]["ui"] == {
+        "prefersBorder": False,
+        "csp": {"connectDomains": [], "resourceDomains": []},
     }
     assert {
         "get_document_review_data",
@@ -139,6 +178,10 @@ def test_registers_portable_resource_and_decoupled_tools() -> None:
         "render_reconciliation_cockpit",
         "get_ledger_explorer_data",
         "render_ledger_explorer",
+        "get_tax_filing_data",
+        "get_tax_submission_status_data",
+        "render_tax_preview",
+        "render_tax_submission",
     } == set(mcp.tools)
     for name in (
         "render_document_review",
@@ -148,6 +191,10 @@ def test_registers_portable_resource_and_decoupled_tools() -> None:
         meta = mcp.tool_options[name]["meta"]
         assert meta["ui"]["resourceUri"] == APP_RESOURCE_URI
         assert meta["openai/outputTemplate"] == APP_RESOURCE_URI
+    for name in ("render_tax_preview", "render_tax_submission"):
+        meta = mcp.tool_options[name]["meta"]
+        assert meta["ui"]["resourceUri"] == TAX_APP_RESOURCE_URI
+        assert meta["openai/outputTemplate"] == TAX_APP_RESOURCE_URI
 
 
 def test_widget_is_self_contained_and_uses_standard_bridge() -> None:
@@ -174,6 +221,24 @@ def test_widget_uses_flat_norman_layout_without_wasting_table_width() -> None:
     assert "border-radius:8px" not in html
     assert ".detail.with-inspector" in html
     assert 'class="detail ${inspector?"with-inspector":""}"' in html
+
+
+def test_tax_widget_uses_portable_bridge_and_requires_explicit_confirmation() -> None:
+    mcp, _api = _registered()
+    html = asyncio.run(mcp.resources[TAX_APP_RESOURCE_URI]())
+
+    assert "ui/notifications/tool-result" in html
+    assert 'request("ui/initialize"' in html
+    assert 'request("tools/call"' in html
+    assert 'request("ui/message"' in html
+    assert 'request("ui/open-link"' in html
+    assert 'callTool("submit_tax_report"' in html
+    assert "I reviewed the Finanzamt preview" in html
+    assert "if(!reportId||!state.confirmed||!state.data?.canSubmit)return" in html
+    assert "toolResponseMetadata" in html
+    assert "border-radius:999px" not in html
+    assert "border-radius:8px" not in html
+    assert "https://" not in html
 
 
 def test_document_and_reconciliation_data_are_compact_and_actionable() -> None:
@@ -233,6 +298,77 @@ def test_ledger_data_drills_down_without_mutation() -> None:
     assert all(method == "GET" for method, _url, _kwargs in api.requests)
 
 
+def test_tax_data_generates_preview_without_exposing_image_to_the_model() -> None:
+    mcp, api = _registered()
+
+    data = asyncio.run(mcp.tools["get_tax_filing_data"](_context(api), "report-1"))
+
+    assert data["report"] == {
+        "id": "report-1",
+        "type": "ADVANCE_SALEX_TAX",
+        "typeName": "Advance VAT return",
+        "referenceName": "UStVA July 2026",
+        "dateFrom": "2026-07-01",
+        "dateTo": "2026-07-31",
+        "dateDue": "2026-08-10",
+        "submissionDate": "",
+        "status": "DRAFT",
+        "statusName": "Draft",
+        "total": "119.00",
+        "currency": "EUR",
+        "reportFile": "",
+        "submitted": False,
+    }
+    assert data["preview"] == {
+        "available": True,
+        "mimeType": "image/jpeg",
+        "downloadUrl": "https://api.norman.finance/previews/report-1.pdf",
+        "error": "",
+    }
+    assert "previewImage" not in data
+    assert data["canSubmit"] is True
+    assert data["items"] == [
+        {
+            "code": "81",
+            "label": "Taxable sales",
+            "net": "100.00",
+            "tax": "19.00",
+            "gross": "119.00",
+        }
+    ]
+    assert [(method, url) for method, url, _kwargs in api.requests] == [
+        (
+            "GET",
+            "https://api.norman.finance/api/v1/companies/company-1/taxes/reports/report-1/",
+        ),
+        (
+            "POST",
+            "https://api.norman.finance/api/v1/companies/company-1/taxes/reports/report-1/"
+            "generate-preview-url/",
+        ),
+    ]
+
+
+def test_tax_rendering_never_calls_the_submission_endpoint() -> None:
+    mcp, api = _registered()
+    ctx = _context(api)
+
+    preview = asyncio.run(mcp.tools["render_tax_preview"](ctx, "report-1"))
+    submission = asyncio.run(mcp.tools["render_tax_submission"](ctx, "report-1"))
+
+    assert preview.structuredContent["section"] == "preview"
+    assert submission.structuredContent["section"] == "submission"
+    assert preview.meta == {
+        "norman/view": "tax-filing",
+        "norman/previewImage": "dGVzdC1wcmV2aWV3",
+    }
+    assert submission.meta == {
+        "norman/view": "tax-filing",
+        "norman/previewImage": "dGVzdC1wcmV2aWV3",
+    }
+    assert all("/submit-report/" not in url for _method, url, _kwargs in api.requests)
+
+
 def test_render_tools_return_structured_content_and_widget_only_meta() -> None:
     mcp, api = _registered()
     result = asyncio.run(
@@ -264,21 +400,31 @@ def test_app_contract_survives_real_mcp_protocol_serialization() -> None:
                 "render_document_review",
                 "render_reconciliation_cockpit",
                 "render_ledger_explorer",
+                "render_tax_preview",
+                "render_tax_submission",
             }
-            for tool in render_tools.values():
+            for name in (
+                "render_document_review",
+                "render_reconciliation_cockpit",
+                "render_ledger_explorer",
+            ):
+                tool = render_tools[name]
                 assert tool.meta["ui"]["resourceUri"] == APP_RESOURCE_URI
                 assert tool.meta["openai/outputTemplate"] == APP_RESOURCE_URI
+            for name in ("render_tax_preview", "render_tax_submission"):
+                tool = render_tools[name]
+                assert tool.meta["ui"]["resourceUri"] == TAX_APP_RESOURCE_URI
+                assert tool.meta["openai/outputTemplate"] == TAX_APP_RESOURCE_URI
 
             resources = await session.list_resources()
-            app_resource = next(
-                resource
-                for resource in resources.resources
-                if str(resource.uri) == APP_RESOURCE_URI
-            )
-            assert app_resource.mimeType == APP_MIME_TYPE
+            for uri in (APP_RESOURCE_URI, TAX_APP_RESOURCE_URI):
+                app_resource = next(
+                    resource for resource in resources.resources if str(resource.uri) == uri
+                )
+                assert app_resource.mimeType == APP_MIME_TYPE
 
-            content = await session.read_resource(APP_RESOURCE_URI)
-            assert content.contents[0].mimeType == APP_MIME_TYPE
-            assert "ui/notifications/tool-result" in content.contents[0].text
+                content = await session.read_resource(uri)
+                assert content.contents[0].mimeType == APP_MIME_TYPE
+                assert "ui/notifications/tool-result" in content.contents[0].text
 
     asyncio.run(exercise_protocol())

--- a/tests/test_public_apps.py
+++ b/tests/test_public_apps.py
@@ -165,6 +165,17 @@ def test_widget_is_self_contained_and_uses_standard_bridge() -> None:
     assert "https://" not in html
 
 
+def test_widget_uses_flat_norman_layout_without_wasting_table_width() -> None:
+    mcp, _api = _registered()
+    html = asyncio.run(mcp.resources[APP_RESOURCE_URI]())
+
+    assert "Plus Jakarta Sans" in html
+    assert "border-radius:999px" not in html
+    assert "border-radius:8px" not in html
+    assert ".detail.with-inspector" in html
+    assert 'class="detail ${inspector?"with-inspector":""}"' in html
+
+
 def test_document_and_reconciliation_data_are_compact_and_actionable() -> None:
     mcp, api = _registered()
     ctx = _context(api)


### PR DESCRIPTION
## Summary
- replace rounded pills and cards with Norman-style flat controls, underline navigation, square buttons, and table dividers
- use Norman typography and tighter accounting-table spacing across Document Review, Reconciliation, and Ledger Explorer
- let Document Review use the full widget width until an inspector is actually open, fixing the clipped columns and empty right rail
- add a separate portable `ui://norman/tax-filing-v1.html` MCP App for Finanzamt test preview and submission review
- keep preview/status tools read-only and the base64 preview image widget-only in `_meta`
- require an explicit checkbox before the widget can invoke the existing destructive `submit_tax_report` tool; rendering and previewing never submit
- use the MCP Apps bridge for tool calls, follow-up messages, result notifications, and PDF links, with `window.openai` as a compatibility fallback
- document the interactive UI use cases, example prompts, supported-host fallback, and submission safety model in a dedicated README section
- disable host-requested widget borders and keep both apps self-contained with empty CSP domain allowlists
- bump the accounting MCP App resource URI to v3 so ChatGPT and Claude do not reuse the cached v2 presentation

## Verification
- `uv run --extra dev pytest -q tests/test_public_apps.py` — 10 passed
- `uv run --extra dev pytest -q --ignore=tests/test_basic.py` — 86 passed, 3 skipped
- `uv run --extra dev black --check norman_mcp/apps/public.py tests/test_public_apps.py` — passed
- `uv run --extra dev isort --check-only norman_mcp/apps/public.py tests/test_public_apps.py` — passed
- `git diff --check` — passed
- local Chromium renders checked at 980 px and 390 px; no page errors or horizontal overflow
- submission control test confirms the button is disabled before acknowledgment and enabled only after the checkbox

## Safety
- no deployment or production submission was performed
- the widget does not call `/submit-report/` during data load, preview generation, or rendering
- actual filing remains a separate non-idempotent, destructive MCP tool call and may trigger host confirmation