### PR TITLE
Fix MCP safety metadata for plugin v2 submission

### DIFF
--- a/norman_mcp/tools/categories.py
+++ b/norman_mcp/tools/categories.py
@@ -78,7 +78,7 @@ def register_category_tools(mcp):
             readOnlyHint=True,
             destructiveHint=False,
             idempotentHint=False,
-            openWorldHint=True,
+            openWorldHint=False,
         ),
     )
     async def suggest_skr_category(

--- a/norman_mcp/tools/company.py
+++ b/norman_mcp/tools/company.py
@@ -210,9 +210,9 @@ def register_company_tools(mcp):
     @mcp.tool(
         title="Trigger DATEV Export",
         annotations=ToolAnnotations(
-            readOnlyHint=True,
+            readOnlyHint=False,
             destructiveHint=False,
-            idempotentHint=False,
+            idempotentHint=True,
             openWorldHint=False,
         ),
     )
@@ -221,6 +221,18 @@ def register_company_tools(mcp):
         date_from: str = Field(description="Start date for export in YYYY-MM-DD format"),
         date_to: str = Field(description="End date for export in YYYY-MM-DD format"),
         include_documents: bool = Field(default=True, description="Whether to include attached documents in the ZIP"),
+        advisor_number: Optional[str] = Field(
+            default=None,
+            description="DATEV advisor number; uses the value saved on the company when omitted",
+        ),
+        client_number: Optional[str] = Field(
+            default=None,
+            description="DATEV client/Mandant number; uses the value saved on the company when omitted",
+        ),
+        skr_variant: Optional[str] = Field(
+            default=None,
+            description="SKR03 or SKR04; uses the company's chart of accounts when omitted",
+        ),
     ) -> Dict[str, Any]:
         """
         Trigger a DATEV export for the company's transactions in the specified period.
@@ -233,15 +245,35 @@ def register_company_tools(mcp):
         if not company_id:
             return {"error": "No company available. Please authenticate first."}
         
-        export_url = urljoin(
-            config.api_base_url,
-            f"api/v1/companies/{company_id}/accounting/datev-export/"
-        )
+        company_url = urljoin(config.api_base_url, f"api/v1/companies/{company_id}/")
+        company = api._make_request("GET", company_url)
+        if company.get("error"):
+            return company
+
+        resolved_advisor_number = advisor_number or company.get("datevAdvisorNumber")
+        resolved_client_number = client_number or company.get("datevClientNumber")
+        if not resolved_advisor_number or not resolved_client_number:
+            return {
+                "error": "DATEV advisor number and client number are required.",
+                "action": (
+                    "Provide advisor_number and client_number, or save them on the company "
+                    "with update_company_details first."
+                ),
+            }
+
+        resolved_skr_variant = skr_variant or str(company.get("chartOfAccounts") or "SKR04").upper()
+        if resolved_skr_variant not in {"SKR03", "SKR04"}:
+            return {"error": "skr_variant must be SKR03 or SKR04."}
+
+        export_url = urljoin(config.api_base_url, "api/v1/accounting/datev-export/")
         
         export_data = {
             "dateFrom": date_from,
             "dateTo": date_to,
             "includeDocuments": include_documents,
+            "advisorNumber": resolved_advisor_number,
+            "clientNumber": resolved_client_number,
+            "skrVariant": resolved_skr_variant,
         }
         
         return api._make_request("POST", export_url, json_data=export_data)

--- a/norman_mcp/tools/corporate_tax_registration.py
+++ b/norman_mcp/tools/corporate_tax_registration.py
@@ -3,6 +3,7 @@ from typing import Any
 from urllib.parse import urljoin
 
 from norman_mcp.context import Context
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from norman_mcp import config
@@ -22,6 +23,10 @@ CORPORATE_CHOICES: dict[str, dict[str, str]] = {
     "salutation": {"1": "Herr", "2": "Frau"},
     "shareholderType": {"natural": "Natural person", "legal": "Legal entity (a company)"},
 }
+
+READ_ONLY = ToolAnnotations(readOnlyHint=True, openWorldHint=False, destructiveHint=False)
+WRITE = ToolAnnotations(readOnlyHint=False, openWorldHint=False, destructiveHint=False)
+DESTRUCTIVE_WRITE = ToolAnnotations(readOnlyHint=False, openWorldHint=False, destructiveHint=True)
 
 PERSON_SHAPE = (
     "Person dict keys (camelCase): salutation ('1' Herr / '2' Frau), firstName, lastName, "
@@ -68,7 +73,7 @@ def register_corporate_tax_registration_tools(mcp):
     themselves. Always finish by handing over the submission link.
     """
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def get_corporate_tax_registration(ctx: Context) -> dict[str, Any]:
         """Get the user's corporate tax registration (Fragebogen), if any. Call this FIRST.
 
@@ -80,12 +85,12 @@ def register_corporate_tax_registration_tools(mcp):
         api = ctx.request_context.lifespan_context.get("api")
         return api._make_request("GET", _corporate_url("my/"))
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def get_corporate_tax_registration_choices(ctx: Context) -> dict[str, Any]:
         """Get the valid values for the corporate Fragebogen enum fields (value → label)."""
         return CORPORATE_CHOICES
 
-    @mcp.tool()
+    @mcp.tool(annotations=WRITE)
     async def create_corporate_tax_registration(
         ctx: Context,
         incorporation_public_id: str | None = Field(
@@ -107,7 +112,7 @@ def register_corporate_tax_registration_tools(mcp):
         payload = _clean({"source": NORMAN_AGENT_SOURCE, "incorporation": incorporation_public_id})
         return api._make_request("POST", _corporate_url(), json_data=payload)
 
-    @mcp.tool()
+    @mcp.tool(annotations=WRITE)
     async def update_corporate_company(  # noqa: PLR0913
         ctx: Context,
         public_id: str = Field(description="Corporate tax registration publicId"),
@@ -161,7 +166,7 @@ def register_corporate_tax_registration_tools(mcp):
         )
         return api._make_request("PATCH", _corporate_url(f"{public_id}/"), json_data=payload)
 
-    @mcp.tool()
+    @mcp.tool(annotations=WRITE)
     async def update_corporate_registration_details(  # noqa: PLR0913
         ctx: Context,
         public_id: str = Field(description="Corporate tax registration publicId"),
@@ -193,7 +198,7 @@ def register_corporate_tax_registration_tools(mcp):
         )
         return api._make_request("PATCH", _corporate_url(f"{public_id}/"), json_data=payload)
 
-    @mcp.tool()
+    @mcp.tool(annotations=DESTRUCTIVE_WRITE)
     async def set_corporate_people(
         ctx: Context,
         public_id: str = Field(description="Corporate tax registration publicId"),
@@ -220,7 +225,7 @@ def register_corporate_tax_registration_tools(mcp):
         payload = _clean({"representatives": representatives, "shareholderEntries": shareholder_entries})
         return api._make_request("PATCH", _corporate_url(f"{public_id}/"), json_data=payload)
 
-    @mcp.tool()
+    @mcp.tool(annotations=WRITE)
     async def update_corporate_financials(  # noqa: PLR0913
         ctx: Context,
         public_id: str = Field(description="Corporate tax registration publicId"),
@@ -248,7 +253,7 @@ def register_corporate_tax_registration_tools(mcp):
         )
         return api._make_request("PATCH", _corporate_url(f"{public_id}/"), json_data=payload)
 
-    @mcp.tool()
+    @mcp.tool(annotations=WRITE)
     async def update_corporate_vat_and_bank(  # noqa: PLR0913
         ctx: Context,
         public_id: str = Field(description="Corporate tax registration publicId"),
@@ -294,7 +299,7 @@ def register_corporate_tax_registration_tools(mcp):
         )
         return api._make_request("PATCH", _corporate_url(f"{public_id}/"), json_data=payload)
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def get_corporate_submission_link(ctx: Context) -> dict[str, Any]:
         """The FINAL step: hand the user over to the Norman app to review and submit.
 

--- a/norman_mcp/tools/gewerbe_registration.py
+++ b/norman_mcp/tools/gewerbe_registration.py
@@ -5,6 +5,7 @@ from urllib.parse import urljoin
 
 from norman_mcp.context import Context
 from mcp.server.fastmcp.utilities.types import Image
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from norman_mcp import config
@@ -37,6 +38,9 @@ GEWERBE_CHOICES: dict[str, dict[str, str]] = {
     "gender": {"male": "Male", "female": "Female", "diverse": "Diverse"},
 }
 
+READ_ONLY = ToolAnnotations(readOnlyHint=True, openWorldHint=False, destructiveHint=False)
+WRITE = ToolAnnotations(readOnlyHint=False, openWorldHint=False, destructiveHint=False)
+
 
 def _gewerbe_url(path: str = "") -> str:
     return urljoin(config.api_base_url, f"api/v1/gewerbe-registrations/{path}")
@@ -65,7 +69,7 @@ def register_gewerbe_registration_tools(mcp):
     line.
     """
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def get_gewerbe_registration(ctx: Context) -> dict[str, Any]:
         """Get the user's Gewerbeanmeldung, if any. Call this FIRST.
 
@@ -76,12 +80,12 @@ def register_gewerbe_registration_tools(mcp):
         api = ctx.request_context.lifespan_context.get("api")
         return api._make_request("GET", _gewerbe_url("my/"))
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def get_gewerbe_registration_choices(ctx: Context) -> dict[str, Any]:  # noqa: ARG001
         """Get the valid values for the Gewerbeanmeldung enum fields (value → label)."""
         return GEWERBE_CHOICES
 
-    @mcp.tool()
+    @mcp.tool(annotations=WRITE)
     async def create_gewerbe_registration(
         ctx: Context,
         incorporation_public_id: str | None = Field(
@@ -99,7 +103,7 @@ def register_gewerbe_registration_tools(mcp):
         payload = _clean({"source": NORMAN_AGENT_SOURCE, "incorporation": incorporation_public_id})
         return api._make_request("POST", _gewerbe_url(), json_data=payload)
 
-    @mcp.tool()
+    @mcp.tool(annotations=WRITE)
     async def update_gewerbe_basic(
         ctx: Context,
         public_id: str = Field(description="Gewerbeanmeldung publicId"),
@@ -111,7 +115,7 @@ def register_gewerbe_registration_tools(mcp):
         payload = _clean({"activityStartDate": activity_start_date, "establishmentType": establishment_type})
         return api._make_request("PATCH", _gewerbe_url(f"{public_id}/"), json_data=payload)
 
-    @mcp.tool()
+    @mcp.tool(annotations=WRITE)
     async def update_gewerbe_business(  # noqa: PLR0913
         ctx: Context,
         public_id: str = Field(description="Gewerbeanmeldung publicId"),
@@ -162,7 +166,7 @@ def register_gewerbe_registration_tools(mcp):
         )
         return api._make_request("PATCH", _gewerbe_url(f"{public_id}/"), json_data=payload)
 
-    @mcp.tool()
+    @mcp.tool(annotations=WRITE)
     async def update_gewerbe_owner(  # noqa: PLR0913
         ctx: Context,
         public_id: str = Field(description="Gewerbeanmeldung publicId"),
@@ -211,7 +215,7 @@ def register_gewerbe_registration_tools(mcp):
         )
         return api._make_request("PATCH", _gewerbe_url(f"{public_id}/"), json_data=payload)
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def suggest_gewerbe_activity(
         ctx: Context,
         public_id: str = Field(description="Gewerbeanmeldung publicId"),
@@ -226,7 +230,7 @@ def register_gewerbe_registration_tools(mcp):
         api = ctx.request_context.lifespan_context.get("api")
         return api._make_request("POST", _gewerbe_url(f"{public_id}/suggest-activity/"), json_data={"draft": draft})
 
-    @mcp.tool()
+    @mcp.tool(annotations=WRITE)
     async def generate_gewerbe_document(
         ctx: Context,
         public_id: str = Field(description="Gewerbeanmeldung publicId"),
@@ -241,7 +245,7 @@ def register_gewerbe_registration_tools(mcp):
         api = ctx.request_context.lifespan_context.get("api")
         return api._make_request("POST", _gewerbe_url(f"{public_id}/documents/"), json_data={})
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def get_gewerbe_document_preview(
         ctx: Context,
         public_id: str = Field(description="Gewerbeanmeldung publicId"),
@@ -255,7 +259,7 @@ def register_gewerbe_registration_tools(mcp):
             return {"error": "No preview available. Generate the document first."}
         return Image(data=base64.b64decode(preview), format="jpeg")
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def get_gewerbe_trade_office(
         ctx: Context,
         public_id: str = Field(description="Gewerbeanmeldung publicId"),

--- a/norman_mcp/tools/incorporation.py
+++ b/norman_mcp/tools/incorporation.py
@@ -5,6 +5,7 @@ from urllib.parse import urljoin
 
 from norman_mcp.context import Context
 from mcp.server.fastmcp.utilities.types import Image
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from norman_mcp import config
@@ -20,6 +21,11 @@ INCORPORATION_CHOICE_TYPES = (
     "notarization-types",
     "notarization-timeframes",
 )
+
+READ_ONLY = ToolAnnotations(readOnlyHint=True, openWorldHint=False, destructiveHint=False)
+WRITE = ToolAnnotations(readOnlyHint=False, openWorldHint=False, destructiveHint=False)
+DESTRUCTIVE_WRITE = ToolAnnotations(readOnlyHint=False, openWorldHint=False, destructiveHint=True)
+EXTERNAL_IRREVERSIBLE_WRITE = ToolAnnotations(readOnlyHint=False, openWorldHint=True, destructiveHint=True)
 
 
 def _incorporations_url(path: str = "") -> str:
@@ -45,7 +51,7 @@ def register_incorporation_tools(mcp):
     freelancer default) so bookkeeping and taxes are set up correctly from the start.
     """
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def get_incorporation(ctx: Context) -> dict[str, Any]:
         """Get the user's active company incorporation (GmbH/UG founding), if any.
 
@@ -56,7 +62,7 @@ def register_incorporation_tools(mcp):
         api = ctx.request_context.lifespan_context.get("api")
         return api._make_request("GET", _incorporations_url("my/"))
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def get_incorporation_choices(
         ctx: Context,
         choice_type: str = Field(
@@ -73,7 +79,7 @@ def register_incorporation_tools(mcp):
             return {"choices": response}
         return response
 
-    @mcp.tool()
+    @mcp.tool(annotations=WRITE)
     async def create_incorporation(
         ctx: Context,
         legal_form: str | None = Field(default=None, description="'ug' or 'gmbh' if already known"),
@@ -84,12 +90,15 @@ def register_incorporation_tools(mcp):
         Section 1/5 begins here. Save `publicId` from the response for all subsequent calls.
         Fails with a validation error if an active incorporation already exists —
         use get_incorporation and continue it instead.
+
+        When legal_form is ug or gmbh, Norman also switches the user's account to the
+        corresponding corporate type and provisions the SKR04 chart of accounts.
         """
         api = ctx.request_context.lifespan_context.get("api")
         payload = _clean({"legalForm": legal_form, "locale": locale, "source": NORMAN_AGENT_SOURCE})
         return api._make_request("POST", _incorporations_url(), json_data=payload)
 
-    @mcp.tool()
+    @mcp.tool(annotations=WRITE)
     async def update_incorporation_company(
         ctx: Context,
         public_id: str = Field(description="Incorporation publicId"),
@@ -141,7 +150,7 @@ def register_incorporation_tools(mcp):
         )
         return api._make_request("PATCH", _incorporations_url(f"{public_id}/"), json_data=payload)
 
-    @mcp.tool()
+    @mcp.tool(annotations=WRITE)
     async def update_incorporation_capital(
         ctx: Context,
         public_id: str = Field(description="Incorporation publicId"),
@@ -162,7 +171,7 @@ def register_incorporation_tools(mcp):
             json_data={"shareCapital": share_capital},
         )
 
-    @mcp.tool()
+    @mcp.tool(annotations=WRITE)
     async def add_incorporation_shareholder(
         ctx: Context,
         public_id: str = Field(description="Incorporation publicId"),
@@ -225,7 +234,7 @@ def register_incorporation_tools(mcp):
         )
         return api._make_request("POST", _incorporations_url(f"{public_id}/shareholders/"), json_data=payload)
 
-    @mcp.tool()
+    @mcp.tool(annotations=WRITE)
     async def update_incorporation_shareholder(
         ctx: Context,
         public_id: str = Field(description="Incorporation publicId"),
@@ -268,7 +277,7 @@ def register_incorporation_tools(mcp):
             json_data=payload,
         )
 
-    @mcp.tool()
+    @mcp.tool(annotations=EXTERNAL_IRREVERSIBLE_WRITE)
     async def invite_incorporation_shareholder(
         ctx: Context,
         public_id: str = Field(description="Incorporation publicId"),
@@ -288,7 +297,7 @@ def register_incorporation_tools(mcp):
             json_data=_clean({"email": email}),
         )
 
-    @mcp.tool()
+    @mcp.tool(annotations=DESTRUCTIVE_WRITE)
     async def remove_incorporation_shareholder(
         ctx: Context,
         public_id: str = Field(description="Incorporation publicId"),
@@ -301,7 +310,7 @@ def register_incorporation_tools(mcp):
             _incorporations_url(f"{public_id}/shareholders/{shareholder_public_id}/"),
         )
 
-    @mcp.tool()
+    @mcp.tool(annotations=WRITE)
     async def set_incorporation_agreement(
         ctx: Context,
         public_id: str = Field(description="Incorporation publicId"),
@@ -321,7 +330,7 @@ def register_incorporation_tools(mcp):
             json_data={"agreementType": agreement_type},
         )
 
-    @mcp.tool()
+    @mcp.tool(annotations=WRITE)
     async def update_incorporation_notary_preferences(
         ctx: Context,
         public_id: str = Field(description="Incorporation publicId"),
@@ -343,7 +352,7 @@ def register_incorporation_tools(mcp):
         )
         return api._make_request("PATCH", _incorporations_url(f"{public_id}/"), json_data=payload)
 
-    @mcp.tool()
+    @mcp.tool(annotations=WRITE)
     async def generate_incorporation_documents(
         ctx: Context,
         public_id: str = Field(description="Incorporation publicId"),
@@ -365,7 +374,7 @@ def register_incorporation_tools(mcp):
                 document.pop("previewImage", None)
         return response
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def get_incorporation_document_preview(
         ctx: Context,
         public_id: str = Field(description="Incorporation publicId"),
@@ -382,7 +391,7 @@ def register_incorporation_tools(mcp):
                 return Image(data=base64.b64decode(document["previewImage"]), format="jpeg")
         return {"error": f"No preview available for '{document_type}'. Generate the documents first."}
 
-    @mcp.tool()
+    @mcp.tool(annotations=EXTERNAL_IRREVERSIBLE_WRITE)
     async def match_incorporation_notaries(
         ctx: Context,
         public_id: str = Field(description="Incorporation publicId"),
@@ -390,7 +399,8 @@ def register_incorporation_tools(mcp):
         """Get up to 3 notaries matching the collected preferences (online capability, city).
 
         Present them to the user as options; they can pick one or request a match without
-        picking (the Norman team assigns one).
+        picking (the Norman team assigns one). The first call records this stage, notifies
+        Norman's incorporation team and may enrich the private directory from public web sources.
         """
         api = ctx.request_context.lifespan_context.get("api")
         response = api._make_request("GET", _incorporations_url(f"{public_id}/notary-matches/"))
@@ -398,7 +408,7 @@ def register_incorporation_tools(mcp):
             return {"notaries": response}
         return response
 
-    @mcp.tool()
+    @mcp.tool(annotations=EXTERNAL_IRREVERSIBLE_WRITE)
     async def request_incorporation_notary(
         ctx: Context,
         public_id: str = Field(description="Incorporation publicId"),
@@ -426,7 +436,7 @@ def register_incorporation_tools(mcp):
             json_data=payload,
         )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def suggest_incorporation_purpose(
         ctx: Context,
         public_id: str = Field(description="Incorporation publicId"),
@@ -447,7 +457,7 @@ def register_incorporation_tools(mcp):
             json_data={"draft": draft},
         )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READ_ONLY)
     async def check_incorporation_name(
         ctx: Context,
         public_id: str = Field(description="Incorporation publicId"),
@@ -471,7 +481,7 @@ def register_incorporation_tools(mcp):
             json_data=payload,
         )
 
-    @mcp.tool()
+    @mcp.tool(annotations=WRITE)
     async def complete_incorporation_step(
         ctx: Context,
         public_id: str = Field(description="Incorporation publicId"),

--- a/norman_mcp/tools/invoices.py
+++ b/norman_mcp/tools/invoices.py
@@ -393,9 +393,9 @@ def register_invoice_tools(mcp):
         title="Send Invoice via Email",
         annotations=ToolAnnotations(
             readOnlyHint=False,
-            destructiveHint=False,
+            destructiveHint=True,
             idempotentHint=False,
-            openWorldHint=False,
+            openWorldHint=True,
         ),
     )
     async def send_invoice(
@@ -449,9 +449,9 @@ def register_invoice_tools(mcp):
         title="Send Overdue Payment Reminder",
         annotations=ToolAnnotations(
             readOnlyHint=False,
-            destructiveHint=False,
+            destructiveHint=True,
             idempotentHint=False,
-            openWorldHint=False,
+            openWorldHint=True,
         ),
     )
     async def send_invoice_overdue_reminder(

--- a/norman_mcp/tools/offers.py
+++ b/norman_mcp/tools/offers.py
@@ -294,9 +294,9 @@ def register_offer_tools(mcp):
         title="Send Offer via Email",
         annotations=ToolAnnotations(
             readOnlyHint=False,
-            destructiveHint=False,
+            destructiveHint=True,
             idempotentHint=False,
-            openWorldHint=False,
+            openWorldHint=True,
         ),
     )
     async def send_offer(

--- a/norman_mcp/tools/tax_advisor.py
+++ b/norman_mcp/tools/tax_advisor.py
@@ -311,7 +311,7 @@ def register_tax_advisor_tools(mcp):
         title="Ping Client for Documents",
         annotations=ToolAnnotations(
             readOnlyHint=False,
-            destructiveHint=False,
+            destructiveHint=True,
             idempotentHint=False,
             openWorldHint=True,
         ),

--- a/norman_mcp/tools/taxes.py
+++ b/norman_mcp/tools/taxes.py
@@ -183,7 +183,7 @@ def register_tax_tools(mcp):
             readOnlyHint=False,
             destructiveHint=True,
             idempotentHint=False,
-            openWorldHint=False,
+            openWorldHint=True,
         ),
     )
     async def submit_tax_report(
@@ -376,4 +376,4 @@ def register_tax_tools(mcp):
             f"api/v1/companies/{company_id}/vat-next-report-amount/"
         )
         
-        return api._make_request("GET", vat_url) 
+        return api._make_request("GET", vat_url)

--- a/tests/test_submission_annotations.py
+++ b/tests/test_submission_annotations.py
@@ -1,0 +1,178 @@
+import asyncio
+from types import SimpleNamespace
+
+from mcp.server.fastmcp import FastMCP
+
+from norman_mcp.tools.company import register_company_tools
+from norman_mcp.tools.categories import register_category_tools
+from norman_mcp.tools.corporate_tax_registration import register_corporate_tax_registration_tools
+from norman_mcp.tools.gewerbe_registration import register_gewerbe_registration_tools
+from norman_mcp.tools.incorporation import register_incorporation_tools
+from norman_mcp.tools.invoices import register_invoice_tools
+from norman_mcp.tools.offers import register_offer_tools
+from norman_mcp.tools.tax_advisor import register_tax_advisor_tools
+from norman_mcp.tools.taxes import register_tax_tools
+
+
+READ_ONLY = (True, False, False)
+WRITE = (False, False, False)
+DESTRUCTIVE_WRITE = (False, False, True)
+EXTERNAL_IRREVERSIBLE_WRITE = (False, True, True)
+
+
+def _annotation_tuple(tool):  # noqa: ANN001, ANN202
+    annotations = tool.annotations
+    return (
+        annotations.readOnlyHint,
+        annotations.openWorldHint,
+        annotations.destructiveHint,
+    )
+
+
+def test_registration_tools_advertise_truthful_submission_annotations() -> None:
+    server = FastMCP()
+    register_incorporation_tools(server)
+    register_gewerbe_registration_tools(server)
+    register_corporate_tax_registration_tools(server)
+    tools = server._tool_manager._tools  # noqa: SLF001
+
+    expected = {
+        "get_incorporation": READ_ONLY,
+        "get_incorporation_choices": READ_ONLY,
+        "create_incorporation": WRITE,
+        "update_incorporation_company": WRITE,
+        "update_incorporation_capital": WRITE,
+        "add_incorporation_shareholder": WRITE,
+        "update_incorporation_shareholder": WRITE,
+        "invite_incorporation_shareholder": EXTERNAL_IRREVERSIBLE_WRITE,
+        "remove_incorporation_shareholder": DESTRUCTIVE_WRITE,
+        "set_incorporation_agreement": WRITE,
+        "update_incorporation_notary_preferences": WRITE,
+        "generate_incorporation_documents": WRITE,
+        "get_incorporation_document_preview": READ_ONLY,
+        "match_incorporation_notaries": EXTERNAL_IRREVERSIBLE_WRITE,
+        "request_incorporation_notary": EXTERNAL_IRREVERSIBLE_WRITE,
+        "suggest_incorporation_purpose": READ_ONLY,
+        "check_incorporation_name": READ_ONLY,
+        "complete_incorporation_step": WRITE,
+        "get_gewerbe_registration": READ_ONLY,
+        "get_gewerbe_registration_choices": READ_ONLY,
+        "create_gewerbe_registration": WRITE,
+        "update_gewerbe_basic": WRITE,
+        "update_gewerbe_business": WRITE,
+        "update_gewerbe_owner": WRITE,
+        "suggest_gewerbe_activity": READ_ONLY,
+        "generate_gewerbe_document": WRITE,
+        "get_gewerbe_document_preview": READ_ONLY,
+        "get_gewerbe_trade_office": READ_ONLY,
+        "get_corporate_tax_registration": READ_ONLY,
+        "get_corporate_tax_registration_choices": READ_ONLY,
+        "create_corporate_tax_registration": WRITE,
+        "update_corporate_company": WRITE,
+        "update_corporate_registration_details": WRITE,
+        "set_corporate_people": DESTRUCTIVE_WRITE,
+        "update_corporate_financials": WRITE,
+        "update_corporate_vat_and_bank": WRITE,
+        "get_corporate_submission_link": READ_ONLY,
+    }
+
+    assert set(tools) == set(expected)
+    assert {name: _annotation_tuple(tool) for name, tool in tools.items()} == expected
+
+
+def test_external_actions_and_internal_ai_use_truthful_annotations() -> None:
+    server = FastMCP()
+    register_invoice_tools(server)
+    register_offer_tools(server)
+    register_tax_advisor_tools(server)
+    register_tax_tools(server)
+    register_category_tools(server)
+    tools = server._tool_manager._tools  # noqa: SLF001
+
+    assert _annotation_tuple(tools["send_invoice"]) == EXTERNAL_IRREVERSIBLE_WRITE
+    assert _annotation_tuple(tools["send_invoice_overdue_reminder"]) == EXTERNAL_IRREVERSIBLE_WRITE
+    assert _annotation_tuple(tools["send_offer"]) == EXTERNAL_IRREVERSIBLE_WRITE
+    assert _annotation_tuple(tools["ping_client_for_documents"]) == EXTERNAL_IRREVERSIBLE_WRITE
+    assert _annotation_tuple(tools["submit_tax_report"]) == EXTERNAL_IRREVERSIBLE_WRITE
+    assert _annotation_tuple(tools["suggest_skr_category"]) == READ_ONLY
+
+
+def test_every_exposed_tool_sets_all_required_submission_hints() -> None:
+    from norman_mcp.server import mcp
+
+    for tool in mcp._tool_manager._tools.values():  # noqa: SLF001
+        assert None not in _annotation_tuple(tool), tool.name
+
+
+class _DatevApi:
+    company_id = "company-1"
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    def _make_request(self, method, url, params=None, json_data=None):  # noqa: ANN001, ANN202
+        self.calls.append((method, url, params, json_data))
+        if method == "GET":
+            return {
+                "datevAdvisorNumber": "1234",
+                "datevClientNumber": "5678",
+                "chartOfAccounts": "skr03",
+            }
+        return {"success": True}
+
+
+def test_datev_export_uses_live_endpoint_and_saved_company_settings() -> None:
+    server = FastMCP()
+    register_company_tools(server)
+    tool = server._tool_manager._tools["trigger_datev_export"]  # noqa: SLF001
+    api = _DatevApi()
+    ctx = SimpleNamespace(request_context=SimpleNamespace(lifespan_context={"api": api}))
+
+    result = asyncio.run(
+        tool.fn(
+            ctx,
+            date_from="2026-01-01",
+            date_to="2026-12-31",
+            include_documents=True,
+            advisor_number=None,
+            client_number=None,
+            skr_variant=None,
+        ),
+    )
+
+    assert result == {"success": True}
+    method, url, _params, payload = api.calls[-1]
+    assert method == "POST"
+    assert url.endswith("/api/v1/accounting/datev-export/")
+    assert payload == {
+        "dateFrom": "2026-01-01",
+        "dateTo": "2026-12-31",
+        "includeDocuments": True,
+        "advisorNumber": "1234",
+        "clientNumber": "5678",
+        "skrVariant": "SKR03",
+    }
+    assert _annotation_tuple(tool) == WRITE
+
+
+def test_datev_export_requires_datev_numbers_before_requesting_export() -> None:
+    server = FastMCP()
+    register_company_tools(server)
+    tool = server._tool_manager._tools["trigger_datev_export"]  # noqa: SLF001
+    api = _DatevApi()
+    api._make_request = lambda method, url, params=None, json_data=None: {}  # type: ignore[method-assign]
+    ctx = SimpleNamespace(request_context=SimpleNamespace(lifespan_context={"api": api}))
+
+    result = asyncio.run(
+        tool.fn(
+            ctx,
+            date_from="2026-01-01",
+            date_to="2026-12-31",
+            include_documents=True,
+            advisor_number=None,
+            client_number=None,
+            skr_variant=None,
+        ),
+    )
+
+    assert result["error"] == "DATEV advisor number and client number are required."


### PR DESCRIPTION
## Summary
- add explicit read/open-world/destructive annotations to all incorporation, Gewerbe, and corporate tax registration tools
- mark email, external filing, and notary actions as external irreversible operations
- point DATEV export at the live API contract and reuse saved DATEV/SKR settings
- add regression coverage for all 161 exposed tool annotations

## Verification
- `uv run ruff check` on changed Python files
- `uv run --with pytest pytest -q --ignore=tests/test_basic.py` (90 passed, 3 skipped)
- full suite collection still has the pre-existing `tests/test_basic.py` import of removed `Config`/`NormanAPI` symbols

Prepared for the Norman 2.0.0 OpenAI plugin rescan.