### PR TITLE
feat: send the active company as X-Company-Id

### DIFF
--- a/norman_mcp/api/client.py
+++ b/norman_mcp/api/client.py
@@ -340,7 +340,10 @@ class NormanAPI:
                 logger.warning("No companies found for user")
                 return None
 
-            # Use the first company
+            # First entry = the company this user activated most recently (the API orders
+            # the list by the caller's own last_active_at), so a caller who switched
+            # companies lands back on that one even after their MCP token was refreshed
+            # and the per-token selection was lost.
             company_id = companies[0].get("publicId")
             if company_id:
                 logger.info(f"✅ Using company ID from API: {company_id}")
@@ -419,6 +422,19 @@ class NormanAPI:
             "X-Frame-Options": "DENY",
         }
 
+        # The active company, as the API expects it. Tools scope most calls through the
+        # URL (/companies/<id>/...), but every endpoint that resolves the company itself
+        # reads this header; without it the backend falls back to the caller's
+        # last-activated company, which is not necessarily the one selected here.
+        # `self.company_id` is request-scoped (see the property), so this can only ever
+        # be the calling user's own company. The companies list is not scoped: it is how
+        # a caller discovers which companies they have.
+        if not url.endswith("companies/"):
+            company_id = self.company_id
+            if company_id:
+                logger.debug(f"Using company ID for request: {company_id}")
+                headers["X-Company-Id"] = company_id
+
         # Log token source for debugging
         logger.debug(
             f"Making API request to {url} with token source: {self.token_source}"
@@ -426,16 +442,6 @@ class NormanAPI:
 
         if params is None:
             params = {}
-
-        # Add company ID to params if we have one and the URL requires it.
-        # `self.company_id` is request-scoped (see the property), so this can
-        # only ever be the calling user's own company.
-        if not url.endswith("companies/"):
-            company_id = self.company_id
-            if company_id:
-                logger.debug(f"Using company ID for request: {company_id}")
-                if "companyId" not in params:
-                    params["companyId"] = company_id
 
         # Sanitize parameters to prevent injection
         if params:

--- a/norman_mcp/tools/tax_advisor.py
+++ b/norman_mcp/tools/tax_advisor.py
@@ -438,6 +438,15 @@ def register_tax_advisor_tools(mcp):
 
         api.set_company(company_id)
 
+        # Remember the choice server-side as well. The per-token selection above is lost
+        # when the MCP token is refreshed (~24h); the API's last-active company is not,
+        # and it is what a request without an X-Company-Id header resolves to.
+        activate_url = urljoin(config.api_base_url, f"api/v1/companies/{company_id}/activate/")
+        try:
+            api._make_request("POST", activate_url)
+        except Exception as e:  # noqa: BLE001 - best effort, the switch itself already happened
+            logger.warning(f"Could not mark {company_id} as the last active company: {e}")
+
         return {
             "previousCompanyId": previous_id,
             "activeCompanyId": company_id,

--- a/tests/test_company_header.py
+++ b/tests/test_company_header.py
@@ -1,0 +1,167 @@
+"""The active company travels as `X-Company-Id`, the way the API expects it.
+
+Tools scope most calls through the URL (`/companies/<id>/...`), but every endpoint
+that resolves the company server-side reads the header. We used to send a `companyId`
+query parameter instead, which the API ignores: those endpoints silently answered for
+whichever company the backend picked on its own, not the one `switch_company` chose.
+"""
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urljoin, urlparse
+
+import pytest
+from mcp.server.auth.middleware.auth_context import auth_context_var
+from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
+from mcp.server.auth.provider import AccessToken
+
+from norman_mcp import context
+from norman_mcp.api import client as client_module
+from norman_mcp.api.client import NormanAPI
+
+MCP_TOKEN = "mcp_a"
+NORMAN_TOKEN = "norman_a"
+
+
+@pytest.fixture(autouse=True)
+def disable_actual_api_calls():
+    """Override the global autouse fixture: these tests need real HTTP."""
+    yield
+
+
+class _RecordingHandler(BaseHTTPRequestHandler):
+    def _record_and_reply(self) -> None:
+        parsed = urlparse(self.path)
+        self.server.seen.append(
+            {
+                "path": parsed.path,
+                "query": parse_qs(parsed.query),
+                "company_header": self.headers.get("X-Company-Id"),
+            },
+        )
+        body = (
+            {"results": [{"publicId": "co-default"}]}
+            if parsed.path == "/api/v1/companies/"
+            else {"ok": True}
+        )
+        payload = json.dumps(body).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    do_GET = _record_and_reply  # noqa: N815 - BaseHTTPRequestHandler API
+    do_POST = _record_and_reply  # noqa: N815
+
+    def log_message(self, *args) -> None:
+        pass
+
+
+class _FakeProvider:
+    def __init__(self) -> None:
+        self.token_to_company_id: dict[str, str] = {}
+
+    def get_norman_token(self, mcp_token):  # noqa: ANN001, ANN201
+        return NORMAN_TOKEN if mcp_token == MCP_TOKEN else None
+
+    def get_company_for_token(self, mcp_token):  # noqa: ANN001, ANN201
+        return self.token_to_company_id.get(mcp_token)
+
+    def set_company_for_token(self, mcp_token, company_id):  # noqa: ANN001, ANN201
+        if mcp_token and company_id:
+            self.token_to_company_id[mcp_token] = company_id
+
+
+@pytest.fixture
+def fake_norman():  # noqa: ANN201
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _RecordingHandler)
+    server.seen = []
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@pytest.fixture
+def api(fake_norman, monkeypatch):  # noqa: ANN001, ANN201
+    host, port = fake_norman.server_address[:2]
+
+    class _Cfg:
+        api_base_url = f"http://{host}:{port}/"
+        NORMAN_API_TIMEOUT = 10
+
+    monkeypatch.setattr(client_module, "config", _Cfg())
+    monkeypatch.setattr(context, "oauth_provider", _FakeProvider())
+    client = NormanAPI(authenticate_on_init=False)
+    client.token_source = "oauth"
+    return client, _Cfg.api_base_url
+
+
+def _in_request(body):  # noqa: ANN001, ANN202
+    """Run `body` in a fresh thread, which is what a fresh request context is."""
+    result, errors = {}, []
+
+    def run() -> None:
+        try:
+            auth_context_var.set(
+                AuthenticatedUser(AccessToken(token=MCP_TOKEN, client_id="c", scopes=["read"])),
+            )
+            context.set_api_token(NORMAN_TOKEN)
+            result["value"] = body()
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    thread = threading.Thread(target=run)
+    thread.start()
+    thread.join(timeout=30)
+    if errors:
+        raise errors[0]
+    return result.get("value")
+
+
+def test_the_active_company_travels_as_a_header(api, fake_norman) -> None:  # noqa: ANN001
+    client, base = api
+
+    _in_request(
+        lambda: (
+            client.set_company("co-chosen"),
+            client._make_request("GET", urljoin(base, "api/v1/accounting/transactions/")),
+        ),
+    )
+
+    call = next(c for c in fake_norman.seen if c["path"].endswith("/transactions/"))
+    assert call["company_header"] == "co-chosen"
+    assert "companyId" not in call["query"], "the inert query parameter is still being sent"
+
+
+def test_the_companies_list_is_not_scoped(api, fake_norman) -> None:  # noqa: ANN001
+    """Listing companies is how a caller discovers them; scoping it would hide the others."""
+    client, base = api
+
+    _in_request(
+        lambda: (
+            client.set_company("co-chosen"),
+            client._make_request("GET", urljoin(base, "api/v1/companies/")),
+        ),
+    )
+
+    call = next(c for c in fake_norman.seen if c["path"] == "/api/v1/companies/")
+    assert call["company_header"] is None
+
+
+def test_without_a_selection_the_first_listed_company_is_used(
+    api, fake_norman
+) -> None:  # noqa: ANN001
+    """The API orders the list by the caller's own last-active company, so the default
+    follows a switch even after the per-token selection was lost to a token refresh."""
+    client, base = api
+
+    _in_request(lambda: client._make_request("GET", urljoin(base, "api/v1/invoices/")))
+
+    call = next(c for c in fake_norman.seen if c["path"].endswith("/invoices/"))
+    assert call["company_header"] == "co-default"


### PR DESCRIPTION
Phase 2 of multi-company, MCP side.

## Summary
- The client sent the active company as a `companyId` **query parameter**, which the API ignores. Tools that build a company-scoped URL (`/companies/<id>/...`) were unaffected, but every endpoint that resolves the company server-side answered for whichever company the backend picked on its own — not the one `switch_company` had selected. It now travels as `X-Company-Id`, the header the API reads, and the inert parameter is gone. The companies list stays unscoped: that is how a caller discovers their companies.
- `switch_company` additionally marks the company as last active (`POST /companies/{id}/activate/`, best effort, after the access check that already gates the switch). The per-token selection is lost when the MCP token is refreshed — roughly daily, a limitation documented in `auth/provider.py` — whereas the server-side last-active company is not, and it is exactly what a request without the header resolves to. A switch now survives the refresh instead of snapping back to another company.
- With several legal entities per account (the multi-company work on the API side), the first entry of `GET /companies/` is the caller's most recently activated company, so the fallback follows the user rather than picking the oldest entity.

## Validation
- New `tests/test_company_header.py` (3): the header carries the selection and the query parameter is gone; the companies list is not scoped; without a selection the first listed company is used.
- 18 passed across `test_company_header`, `test_company_selection`, `test_tenant_isolation`, `test_api_client_async`, `test_company_lookup_refresh`.
- Full suite: 93 passed, 3 skipped, 3 failed — all three (`test_public_apps`, `test_redirect_allowlist`, `test_submission_annotations`) and the `test_basic.py` collection error reproduce unchanged on `origin/main` in this environment.
- Black: the new test file is formatted; the two touched source files were already non-compliant at `main` and my hunks add no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
