### PR TITLE
fix(oauth): restore open DCR for Smithery

### DIFF
--- a/norman_mcp/auth/provider.py
+++ b/norman_mcp/auth/provider.py
@@ -32,6 +32,7 @@ from mcp.server.auth.provider import (
     AuthorizationCode,
     AuthorizationParams,
     OAuthAuthorizationServerProvider,
+    RegistrationError,
     RefreshToken,
     construct_redirect_uri,
 )
@@ -323,25 +324,27 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
     async def register_client(self, client_info: OAuthClientInformationFull) -> None:
         """Register a new OAuth client via Dynamic Client Registration.
 
-        Open DCR is intentional (MCP clients self-register), but we drop any
-        redirect URI that is not on the server allow-list so an attacker cannot
-        persist a code-exfiltration target. The authoritative check still runs
-        per /authorize request via validate_redirect_uri.
+        Open DCR is intentional (MCP clients self-register), but every redirect
+        URI must be on the server allow-list. Reject the complete registration
+        if any URI is disallowed so the SDK can return the RFC 7591 error
+        response instead of rebuilding invalid metadata with no redirect URIs.
+        The authoritative check still runs per /authorize request via
+        validate_redirect_uri.
         """
-        allowed_uris = [u for u in (client_info.redirect_uris or []) if is_allowed_redirect_uri(str(u))]
-        dropped = [str(u) for u in (client_info.redirect_uris or []) if not is_allowed_redirect_uri(str(u))]
-        if dropped:
-            logger.warning(f"DCR for {client_info.client_id}: dropping disallowed redirect_uris: {dropped}")
-        if list(allowed_uris) != list(client_info.redirect_uris or []):
-            client_info = OAuthClientInformationFull(
-                client_id=client_info.client_id,
-                client_name=client_info.client_name,
-                client_secret=client_info.client_secret,
-                redirect_uris=allowed_uris,
-                token_endpoint_auth_method=client_info.token_endpoint_auth_method or "none",
-                grant_types=client_info.grant_types or ["authorization_code", "refresh_token"],
-                response_types=client_info.response_types or ["code"],
-                scope=client_info.scope,
+        disallowed_uris = [
+            str(uri)
+            for uri in (client_info.redirect_uris or [])
+            if not is_allowed_redirect_uri(str(uri))
+        ]
+        if disallowed_uris:
+            logger.warning(
+                "Rejecting DCR for %s: disallowed redirect_uris: %s",
+                client_info.client_id,
+                disallowed_uris,
+            )
+            raise RegistrationError(
+                error="invalid_redirect_uri",
+                error_description="One or more redirect_uris are not allowed",
             )
         if not client_info.scope or not any(s in client_info.scope for s in SUPPORTED_SCOPES):
             client_info = OAuthClientInformationFull(

--- a/norman_mcp/auth/provider.py
+++ b/norman_mcp/auth/provider.py
@@ -32,7 +32,6 @@ from mcp.server.auth.provider import (
     AuthorizationCode,
     AuthorizationParams,
     OAuthAuthorizationServerProvider,
-    RegistrationError,
     RefreshToken,
     construct_redirect_uri,
 )
@@ -324,28 +323,11 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
     async def register_client(self, client_info: OAuthClientInformationFull) -> None:
         """Register a new OAuth client via Dynamic Client Registration.
 
-        Open DCR is intentional (MCP clients self-register), but every redirect
-        URI must be on the server allow-list. Reject the complete registration
-        if any URI is disallowed so the SDK can return the RFC 7591 error
-        response instead of rebuilding invalid metadata with no redirect URIs.
-        The authoritative check still runs per /authorize request via
-        validate_redirect_uri.
+        Open DCR is intentional (MCP clients self-register), so preserve the
+        metadata they submit and return a conforming RFC 7591 success response.
+        Redirect trust is enforced authoritatively on every /authorize request
+        via validate_redirect_uri, before an authorization code can be issued.
         """
-        disallowed_uris = [
-            str(uri)
-            for uri in (client_info.redirect_uris or [])
-            if not is_allowed_redirect_uri(str(uri))
-        ]
-        if disallowed_uris:
-            logger.warning(
-                "Rejecting DCR for %s: disallowed redirect_uris: %s",
-                client_info.client_id,
-                disallowed_uris,
-            )
-            raise RegistrationError(
-                error="invalid_redirect_uri",
-                error_description="One or more redirect_uris are not allowed",
-            )
         if not client_info.scope or not any(s in client_info.scope for s in SUPPORTED_SCOPES):
             client_info = OAuthClientInformationFull(
                 client_id=client_info.client_id,

--- a/norman_mcp/security/redirects.py
+++ b/norman_mcp/security/redirects.py
@@ -38,6 +38,7 @@ _DEFAULT_ALLOWED_HTTPS_HOSTS = {
     "chatgpt.com",
     "claude.ai",
     "claude.com",
+    "connect.smithery.ai",
 }
 
 _LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}

--- a/tests/test_redirect_allowlist.py
+++ b/tests/test_redirect_allowlist.py
@@ -6,9 +6,7 @@ import json
 import pytest
 
 from mcp.server.auth.handlers.register import RegistrationHandler
-from mcp.server.auth.provider import RegistrationError
 from mcp.server.auth.settings import ClientRegistrationOptions
-from mcp.shared.auth import OAuthClientInformationFull
 from starlette.requests import Request
 
 from norman_mcp.auth.provider import NormanOAuthProvider
@@ -142,36 +140,12 @@ def test_dcr_handler_registers_dynamic_smithery_callback():
     assert response_body["client_id"] in handler.provider.clients
 
 
-def test_dcr_handler_returns_oauth_error_for_disallowed_redirect():
+def test_dcr_handler_accepts_dynamic_external_client_metadata():
     handler = _registration_handler()
 
     response = asyncio.run(_register_request(handler, "https://attacker.com/steal"))
 
-    assert response.status_code == 400
-    assert json.loads(response.body) == {
-        "error": "invalid_redirect_uri",
-        "error_description": "One or more redirect_uris are not allowed",
-    }
-    assert handler.provider.clients == {}
-
-
-def test_dcr_rejects_entire_registration_when_one_redirect_is_disallowed():
-    provider = _provider_without_external_state()
-    client_info = OAuthClientInformationFull(
-        client_id="mixed-redirect-client",
-        client_secret=None,
-        redirect_uris=[
-            "https://connect.smithery.ai/smithery-deployments/deployment-id/auth",
-            "https://attacker.com/steal",
-        ],
-        token_endpoint_auth_method="none",
-        grant_types=["authorization_code", "refresh_token"],
-        response_types=["code"],
-        scope="read",
-    )
-
-    with pytest.raises(RegistrationError) as exc_info:
-        asyncio.run(provider.register_client(client_info))
-
-    assert exc_info.value.error == "invalid_redirect_uri"
-    assert provider.clients == {}
+    assert response.status_code == 201
+    response_body = json.loads(response.body)
+    assert response_body["redirect_uris"] == ["https://attacker.com/steal"]
+    assert response_body["client_id"] in handler.provider.clients

--- a/tests/test_redirect_allowlist.py
+++ b/tests/test_redirect_allowlist.py
@@ -1,7 +1,17 @@
 """Redirect-URI allow-list tests (OAuth authorization-code phishing defense)."""
 
+import asyncio
+import json
+
 import pytest
 
+from mcp.server.auth.handlers.register import RegistrationHandler
+from mcp.server.auth.provider import RegistrationError
+from mcp.server.auth.settings import ClientRegistrationOptions
+from mcp.shared.auth import OAuthClientInformationFull
+from starlette.requests import Request
+
+from norman_mcp.auth.provider import NormanOAuthProvider
 from norman_mcp.security.redirects import is_allowed_redirect_uri
 
 
@@ -9,11 +19,15 @@ def test_rejects_external_https():
     # The reported attack: attacker-controlled HTTPS exfiltration target.
     assert is_allowed_redirect_uri("https://attacker.com/steal") is False
     assert is_allowed_redirect_uri("https://norman.finance.attacker.com/cb") is False
+    assert is_allowed_redirect_uri("https://connect.smithery.ai.attacker.com/auth") is False
 
 
 def test_allows_known_connector_https_hosts():
     assert is_allowed_redirect_uri("https://chatgpt.com/connector_platform_oauth_redirect")
     assert is_allowed_redirect_uri("https://claude.ai/api/mcp/auth_callback")
+    assert is_allowed_redirect_uri(
+        "https://connect.smithery.ai/smithery-deployments/deployment-id/auth"
+    )
     # Subdomain of an allow-listed base domain.
     assert is_allowed_redirect_uri("https://mcp.norman.finance/oauth/callback")
 
@@ -63,3 +77,101 @@ def test_sdk_validate_patch_enforces_allowlist():
         fn(_DummyClient(), "https://attacker.com/steal")
 
     assert fn(_DummyClient(), "https://chatgpt.com/cb") == "https://chatgpt.com/cb"
+
+
+def _provider_without_external_state() -> NormanOAuthProvider:
+    provider = object.__new__(NormanOAuthProvider)
+    provider.clients = {}
+    provider._save_state = lambda: None
+    return provider
+
+
+async def _register_request(handler: RegistrationHandler, redirect_uri: str):
+    body = json.dumps(
+        {
+            "client_name": "Connector test client",
+            "redirect_uris": [redirect_uri],
+            "token_endpoint_auth_method": "none",
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "scope": "read",
+        }
+    ).encode()
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/register",
+            "headers": [(b"content-type", b"application/json")],
+        },
+        receive,
+    )
+    return await handler.handle(request)
+
+
+def _registration_handler() -> RegistrationHandler:
+    return RegistrationHandler(
+        provider=_provider_without_external_state(),
+        options=ClientRegistrationOptions(
+            enabled=True,
+            valid_scopes=["read"],
+            default_scopes=["read"],
+        ),
+    )
+
+
+def test_dcr_handler_registers_dynamic_smithery_callback():
+    handler = _registration_handler()
+
+    response = asyncio.run(
+        _register_request(
+            handler,
+            "https://connect.smithery.ai/smithery-deployments/deployment-id/auth",
+        )
+    )
+
+    assert response.status_code == 201
+    response_body = json.loads(response.body)
+    assert response_body["redirect_uris"] == [
+        "https://connect.smithery.ai/smithery-deployments/deployment-id/auth"
+    ]
+    assert response_body["client_id"] in handler.provider.clients
+
+
+def test_dcr_handler_returns_oauth_error_for_disallowed_redirect():
+    handler = _registration_handler()
+
+    response = asyncio.run(_register_request(handler, "https://attacker.com/steal"))
+
+    assert response.status_code == 400
+    assert json.loads(response.body) == {
+        "error": "invalid_redirect_uri",
+        "error_description": "One or more redirect_uris are not allowed",
+    }
+    assert handler.provider.clients == {}
+
+
+def test_dcr_rejects_entire_registration_when_one_redirect_is_disallowed():
+    provider = _provider_without_external_state()
+    client_info = OAuthClientInformationFull(
+        client_id="mixed-redirect-client",
+        client_secret=None,
+        redirect_uris=[
+            "https://connect.smithery.ai/smithery-deployments/deployment-id/auth",
+            "https://attacker.com/steal",
+        ],
+        token_endpoint_auth_method="none",
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        scope="read",
+    )
+
+    with pytest.raises(RegistrationError) as exc_info:
+        asyncio.run(provider.register_client(client_info))
+
+    assert exc_info.value.error == "invalid_redirect_uri"
+    assert provider.clients == {}


### PR DESCRIPTION
## Summary

- preserve Dynamic Client Registration metadata and return the conforming RFC 7591 `201` response for dynamically registered clients
- trust the stable `connect.smithery.ai` origin at authorization time while keeping deployment-specific callback paths dynamic
- keep the authoritative redirect safety check on `/authorize`, before any authorization code is issued
- cover Smithery DCR, open registration for external client metadata, and suffix-confusion rejection

## Verification

- `uv run pytest -q tests/test_redirect_allowlist.py` — 10 passed
- `uv run pytest -q --ignore=tests/test_basic.py` — 98 passed
- `uv run black --check norman_mcp/security/redirects.py tests/test_redirect_allowlist.py`
- `git diff --check`

## Baseline note

The unfiltered suite still stops during collection in existing `tests/test_basic.py`, which imports the removed `Config` symbol from `norman_mcp.server`; this PR does not touch that test or module contract.