### PR TITLE
fix(oauth): synchronize upstream refresh token rotation

### DIFF
--- a/norman_mcp/auth/provider.py
+++ b/norman_mcp/auth/provider.py
@@ -8,6 +8,7 @@ authentication to Norman's OAuth server. It:
 4. Issues MCP tokens that map to Norman tokens
 """
 
+import asyncio
 import json as _json
 import os
 import logging
@@ -33,6 +34,7 @@ from mcp.server.auth.provider import (
     AuthorizationParams,
     OAuthAuthorizationServerProvider,
     RefreshToken,
+    TokenError,
     construct_redirect_uri,
 )
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
@@ -92,6 +94,7 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
         self.token_to_company_id: Dict[str, str] = {}
 
         self._persist_lock = threading.Lock()
+        self._refresh_locks: Dict[str, threading.Lock] = {}
         self._load_state()
         self._register_norman_client()
 
@@ -593,79 +596,43 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
         refresh_token: RefreshToken,
         scopes: list[str],
     ) -> OAuthToken:
-        """Exchange refresh token for new access token."""
-        norman_refresh = self.token_mapping.get(refresh_token.token)
-        if not norman_refresh:
-            raise ValueError("Norman refresh token not found")
-        
-        # Refresh with Norman's token endpoint
-        token_payload = {
-            "grant_type": "refresh_token",
-            "refresh_token": norman_refresh,
-            "client_id": get_norman_oauth_client_id(),
-        }
-        
-        # Add client secret if configured
-        client_secret = get_norman_oauth_client_secret()
-        if client_secret:
-            token_payload["client_secret"] = client_secret
-        
-        try:
-            async with httpx.AsyncClient() as http_client:
-                response = await http_client.post(
-                    self.norman_token_url,
-                    data=token_payload,
-                    timeout=config.NORMAN_API_TIMEOUT
-                )
-                
-                if response.status_code != 200:
-                    raise ValueError(f"Norman refresh failed: {response.status_code}")
-                
-                auth_data = response.json()
-                new_norman_token = auth_data.get("access_token")
-                new_norman_refresh = auth_data.get("refresh_token")
-                
-                if not new_norman_token:
-                    raise ValueError("No access token in refresh response")
-                
-                # Generate new MCP access token
-                new_mcp_token = f"mcp_{secrets.token_hex(32)}"
-                
+        """Refresh off the event loop, sharing the lock with transparent refresh."""
+        return await asyncio.to_thread(
+            self._exchange_refresh_token_sync, client, refresh_token, scopes
+        )
+
+    def _exchange_refresh_token_sync(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: RefreshToken,
+        scopes: list[str],
+    ) -> OAuthToken:
+        with self._refresh_lock_for(refresh_token.token):
+            # Recheck after waiting: the client may have revoked it meanwhile.
+            if refresh_token.token not in self.refresh_tokens:
+                raise TokenError("invalid_grant", "Refresh token no longer available")
+            norman_token, norman_refresh = self._refresh_norman_credentials(refresh_token.token)
+            # Company selection still belongs to the previous MCP access token;
+            # this refresh fix does not migrate that existing per-token state.
+            new_mcp_token = f"mcp_{secrets.token_hex(32)}"
+            with self._persist_lock:
                 self.tokens[new_mcp_token] = AccessToken(
                     token=new_mcp_token,
                     client_id=client.client_id,
                     scopes=scopes or refresh_token.scopes,
                     expires_at=int(time.time()) + 86400,
                 )
-                
-                self.token_mapping[new_mcp_token] = new_norman_token
+                self.token_mapping[new_mcp_token] = norman_token
+                self.token_mapping[f"refresh_for_{new_mcp_token}"] = norman_refresh
+            self._save_state()
 
-                # Update refresh token if new one provided
-                if new_norman_refresh:
-                    self.token_mapping[refresh_token.token] = new_norman_refresh
-                self.token_mapping[f"refresh_for_{new_mcp_token}"] = (
-                    new_norman_refresh or self.token_mapping.get(refresh_token.token)
-                )
-                
-                # Known limitation: the company selected via switch_company is
-                # keyed by MCP access token, so a refresh (>=24h) drops back to
-                # the caller's default company. Carrying it over would need a
-                # session identity spanning token rotations, which the provider
-                # does not have -- deliberately not invented here.
-                logger.info(f"✅ Refreshed MCP token: {new_mcp_token[:15]}...")
-                self._save_state()
-
-                return OAuthToken(
-                    access_token=new_mcp_token,
-                    token_type="bearer",
-                    expires_in=86400,
-                    scope=" ".join(scopes or refresh_token.scopes),
-                    refresh_token=refresh_token.token,
-                )
-                
-        except httpx.RequestError as e:
-            logger.error(f"Network error during token refresh: {e}")
-            raise ValueError(f"Failed to refresh token: {e}")
+            return OAuthToken(
+                access_token=new_mcp_token,
+                token_type="bearer",
+                expires_in=86400,
+                scope=" ".join(scopes or refresh_token.scopes),
+                refresh_token=refresh_token.token,
+            )
 
     async def revoke_token(self, token: str, token_type_hint: Optional[str] = None) -> None:
         """Revoke a token."""
@@ -727,13 +694,50 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
         new Norman access token, or None if refresh is impossible
         (no stored refresh token, or refresh call failed).
         """
+        previous_token = self.token_mapping.get(mcp_token)
+        with self._refresh_lock_for(f"refresh_for_{mcp_token}"):
+            current_token = self.token_mapping.get(mcp_token)
+            if current_token and current_token != previous_token:
+                # Another request already refreshed while this one was waiting.
+                return current_token
+            try:
+                norman_token, _ = self._refresh_norman_credentials(f"refresh_for_{mcp_token}")
+            except (TokenError, HTTPException) as exc:
+                # Never log response bodies or request payloads containing tokens.
+                error_code = exc.error if isinstance(exc, TokenError) else exc.status_code
+                logger.warning("Transparent Norman refresh failed: %s", error_code)
+                return None
+            self._save_state()
+            return norman_token
+
+    def _refresh_lock_for(self, mapping_key: str):
+        """Use the stable MCP refresh handle as the lock identity for a grant.
+
+        Existing state already links both refresh paths by the exact opaque
+        upstream refresh token. Never group by client_id: one MCP client can
+        belong to many independent Norman accounts.
+        """
+        with self._persist_lock:
+            norman_refresh = self.token_mapping.get(mapping_key)
+            lock_key = mapping_key
+            if norman_refresh:
+                lock_key = next(
+                    (
+                        key
+                        for key in list(self.refresh_tokens)
+                        if self.token_mapping.get(key) == norman_refresh
+                    ),
+                    mapping_key,
+                )
+            return self._refresh_locks.setdefault(lock_key, threading.Lock())
+
+    def _refresh_norman_credentials(self, mapping_key: str) -> tuple[str, str]:
+        """Rotate all aliases of one upstream grant; caller holds its refresh lock."""
         import requests as _requests
 
-        norman_refresh = self.token_mapping.get(f"refresh_for_{mcp_token}")
+        norman_refresh = self.token_mapping.get(mapping_key)
         if not norman_refresh:
-            logger.warning("No Norman refresh token stored for mcp_token %s...", mcp_token[:12])
-            return None
-
+            raise TokenError("invalid_grant", "Norman refresh token no longer available")
         token_payload = {
             "grant_type": "refresh_token",
             "refresh_token": norman_refresh,
@@ -749,26 +753,53 @@ class NormanOAuthProvider(OAuthAuthorizationServerProvider):
                 data=token_payload,
                 timeout=config.NORMAN_API_TIMEOUT,
             )
-        except _requests.exceptions.RequestException as e:
-            logger.error("Network error during Norman refresh: %s", e)
-            return None
+        except _requests.exceptions.RequestException:
+            raise HTTPException(
+                503,
+                "Norman authorization service temporarily unavailable",
+                headers={"Retry-After": "5"},
+            ) from None
 
-        if response.status_code != 200:
-            logger.error(
-                "Norman refresh failed for mcp_token %s...: %s",
-                mcp_token[:12], response.status_code,
+        if response.status_code == 429 or response.status_code >= 500:
+            raise HTTPException(
+                503,
+                "Norman authorization service temporarily unavailable",
+                headers={"Retry-After": "5"},
             )
-            return None
-
-        data = response.json()
+        try:
+            data = response.json()
+        except ValueError:
+            raise HTTPException(502, "Invalid response from Norman authorization service") from None
+        if not isinstance(data, dict):
+            raise HTTPException(502, "Invalid response from Norman authorization service")
+        if response.status_code != 200:
+            if response.status_code == 400 and data.get("error") == "invalid_grant":
+                raise TokenError("invalid_grant", "Norman authorization expired; please reconnect")
+            raise HTTPException(502, "Norman authorization service rejected the refresh request")
         new_norman_token = data.get("access_token")
         new_norman_refresh = data.get("refresh_token")
-        if not new_norman_token:
-            return None
+        if new_norman_refresh is None:
+            new_norman_refresh = norman_refresh
+        if (
+            not isinstance(new_norman_token, str)
+            or not new_norman_token
+            or not isinstance(new_norman_refresh, str)
+            or not new_norman_refresh
+        ):
+            raise HTTPException(502, "Invalid response from Norman authorization service")
 
-        self.token_mapping[mcp_token] = new_norman_token
-        if new_norman_refresh:
-            self.token_mapping[f"refresh_for_{mcp_token}"] = new_norman_refresh
-        self._save_state()
-        logger.info("✅ Refreshed Norman token for mcp_token %s...", mcp_token[:12])
-        return new_norman_token
+        # Keep the persisted format compatible with existing sessions. Update
+        # both the client-facing refresh handle and every still-live MCP access
+        # token that shares this exact upstream grant, in either refresh path.
+        with self._persist_lock:
+            for key, value in list(self.token_mapping.items()):
+                if value != norman_refresh:
+                    continue
+                if key in self.refresh_tokens:
+                    self.token_mapping[key] = new_norman_refresh
+                elif key.startswith("refresh_for_"):
+                    self.token_mapping[key] = new_norman_refresh
+                    access_key = key.removeprefix("refresh_for_")
+                    if access_key in self.tokens:
+                        self.token_mapping[access_key] = new_norman_token
+        return new_norman_token, new_norman_refresh

--- a/tests/test_oauth_refresh_rotation.py
+++ b/tests/test_oauth_refresh_rotation.py
@@ -1,0 +1,302 @@
+"""Exercise both refresh paths against a single-use upstream refresh token."""
+
+import asyncio
+import json
+import threading
+import time
+
+import pytest
+import requests
+from mcp.server.auth.handlers.token import TokenHandler
+from mcp.server.auth.middleware.client_auth import ClientAuthenticator
+from mcp.server.auth.provider import AccessToken, RefreshToken
+from mcp.shared.auth import OAuthClientInformationFull
+from pydantic import AnyHttpUrl
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+import norman_mcp.auth.provider as provider_module
+from norman_mcp.auth.provider import NormanOAuthProvider
+
+
+def response(status, body):
+    result = requests.Response()
+    result.status_code = status
+    result._content = json.dumps(body).encode()
+    return result
+
+
+class RotatingUpstream:
+    def __init__(self):
+        self.versions = {"a": 0, "b": 0}
+        self.seen = []
+        self.lock = threading.Lock()
+
+    def post(self, url, data, **kwargs):
+        assert url == "https://norman.example.invalid/token"
+        with self.lock:
+            token = data["refresh_token"]
+            self.seen.append(token)
+            for grant, version in self.versions.items():
+                if token == f"refresh_{grant}_{version}":
+                    self.versions[grant] += 1
+                    return response(
+                        200,
+                        {
+                            "access_token": f"access_{grant}_{version + 1}",
+                            "refresh_token": f"refresh_{grant}_{version + 1}",
+                        },
+                    )
+            return response(400, {"error": "invalid_grant"})
+
+
+@pytest.fixture
+def provider(monkeypatch, tmp_path):
+    monkeypatch.setattr(provider_module, "_STATE_FILE", str(tmp_path / "oauth_state.json"))
+    monkeypatch.setenv("NORMAN_OAUTH_CLIENT_ID", "upstream-client")
+    monkeypatch.delenv("NORMAN_OAUTH_CLIENT_SECRET", raising=False)
+    result = NormanOAuthProvider(AnyHttpUrl("https://mcp.example.invalid"))
+    result.norman_token_url = "https://norman.example.invalid/token"
+    result.clients["shared-client"] = OAuthClientInformationFull(
+        client_id="shared-client",
+        redirect_uris=["https://claude.ai/callback"],
+        token_endpoint_auth_method="none",
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        scope="read write",
+    )
+    for grant in ("a", "b"):
+        access_key = f"mcp_{grant}"
+        refresh_key = f"mcp_refresh_{grant}"
+        result.tokens[access_key] = AccessToken(
+            token=access_key,
+            client_id="shared-client",
+            scopes=["read", "write"],
+            expires_at=int(time.time()) + 86400,
+        )
+        result.refresh_tokens[refresh_key] = RefreshToken(
+            token=refresh_key,
+            client_id="shared-client",
+            scopes=["read", "write"],
+            expires_at=int(time.time()) + 30 * 86400,
+        )
+        result.token_mapping.update(
+            {
+                access_key: f"access_{grant}_0",
+                refresh_key: f"refresh_{grant}_0",
+                f"refresh_for_{access_key}": f"refresh_{grant}_0",
+            }
+        )
+        result.token_to_company_id[access_key] = f"company_{grant}"
+    return result
+
+
+@pytest.fixture
+def upstream(monkeypatch):
+    result = RotatingUpstream()
+    monkeypatch.setattr(requests, "post", result.post)
+
+    # Also isolate the old implementation's async transport for baseline runs.
+    class FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        async def post(self, url, **kwargs):
+            return await asyncio.to_thread(requests.post, url, **kwargs)
+
+    monkeypatch.setattr(provider_module.httpx, "AsyncClient", FakeAsyncClient)
+    return result
+
+
+def token_client(provider):
+    handler = TokenHandler(provider, ClientAuthenticator(provider))
+    app = Starlette(routes=[Route("/token", handler.handle, methods=["POST"])])
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def refresh_request(client, grant="a"):
+    return client.post(
+        "/token",
+        data={
+            "grant_type": "refresh_token",
+            "client_id": "shared-client",
+            "refresh_token": f"mcp_refresh_{grant}",
+        },
+    )
+
+
+def test_transparent_refresh_then_client_refresh_survives_restart(provider, upstream):
+    assert provider.refresh_norman_token_sync("mcp_a") == "access_a_1"
+
+    # The fix must survive a deploy using the existing persisted state format.
+    restored = NormanOAuthProvider(AnyHttpUrl("https://mcp.example.invalid"))
+    restored.norman_token_url = provider.norman_token_url
+    with token_client(restored) as client:
+        result = refresh_request(client)
+    assert result.status_code == 200
+    assert result.json()["refresh_token"] == "mcp_refresh_a"
+    new_access = result.json()["access_token"]
+    assert restored.get_norman_token(new_access) == "access_a_2"
+    assert restored.get_norman_token("mcp_a") == "access_a_2"
+    assert restored.token_mapping["mcp_refresh_a"] == "refresh_a_2"
+    assert upstream.seen == ["refresh_a_0", "refresh_a_1"]
+    assert restored.token_mapping["mcp_refresh_b"] == "refresh_b_0"
+    assert restored.get_norman_token("mcp_b") == "access_b_0"
+    assert restored.get_company_for_token("mcp_b") == "company_b"
+
+
+def test_client_refresh_keeps_older_live_access_token_refreshable(provider, upstream):
+    with token_client(provider) as client:
+        result = refresh_request(client)
+    assert result.status_code == 200
+    new_access = result.json()["access_token"]
+
+    assert provider.refresh_norman_token_sync("mcp_a") == "access_a_2"
+    assert provider.refresh_norman_token_sync(new_access) == "access_a_3"
+    assert provider.get_norman_token("mcp_a") == "access_a_3"
+    assert provider.token_mapping["mcp_refresh_a"] == "refresh_a_3"
+    assert upstream.seen == ["refresh_a_0", "refresh_a_1", "refresh_a_2"]
+
+
+def test_concurrent_refresh_paths_share_a_grant_lock_without_blocking_other_users(
+    provider, upstream, monkeypatch
+):
+    started = threading.Event()
+    release = threading.Event()
+    waiting = threading.Event()
+    original_lock_for = provider._refresh_lock_for
+
+    def observe_waiter(key):
+        lock = original_lock_for(key)
+        if key == "refresh_for_mcp_a":
+            waiting.set()
+        return lock
+
+    monkeypatch.setattr(provider, "_refresh_lock_for", observe_waiter)
+
+    def blocked_post(url, data, **kwargs):
+        if data["refresh_token"] == "refresh_a_0":
+            started.set()
+            assert release.wait(5), "test did not release upstream refresh"
+        return upstream.post(url, data, **kwargs)
+
+    monkeypatch.setattr(requests, "post", blocked_post)
+
+    async def run():
+        client = provider.clients["shared-client"]
+        pending = asyncio.create_task(
+            provider.exchange_refresh_token(client, provider.refresh_tokens["mcp_refresh_a"], [])
+        )
+        follower = None
+        try:
+            assert await asyncio.to_thread(started.wait, 5)
+            follower = asyncio.create_task(
+                asyncio.to_thread(provider.refresh_norman_token_sync, "mcp_a")
+            )
+            assert await asyncio.to_thread(waiting.wait, 5)
+            # Same client_id, different account: its refresh must proceed now.
+            other = await asyncio.wait_for(
+                provider.exchange_refresh_token(
+                    client, provider.refresh_tokens["mcp_refresh_b"], []
+                ),
+                timeout=2,
+            )
+            assert provider.get_norman_token(other.access_token) == "access_b_1"
+        finally:
+            release.set()
+            result = await pending
+            if follower is not None:
+                assert await follower == "access_a_1"
+        assert provider.get_norman_token(result.access_token) == "access_a_1"
+
+    asyncio.run(run())
+    assert sorted(upstream.seen) == ["refresh_a_0", "refresh_b_0"]
+
+
+def test_parallel_client_refreshes_both_succeed(provider, upstream):
+    async def run():
+        return await asyncio.gather(
+            *(
+                provider.exchange_refresh_token(
+                    provider.clients["shared-client"], provider.refresh_tokens["mcp_refresh_a"], []
+                )
+                for _ in range(2)
+            )
+        )
+
+    results = asyncio.run(run())
+    assert len({r.access_token for r in results}) == 2
+    assert upstream.seen == ["refresh_a_0", "refresh_a_1"]
+    for result in results:
+        assert provider.get_norman_token(result.access_token) == "access_a_2"
+        assert provider.token_mapping[f"refresh_for_{result.access_token}"] == "refresh_a_2"
+
+
+def test_refresh_without_rotation_keeps_existing_refresh_token(provider, upstream, monkeypatch):
+    monkeypatch.setattr(
+        requests, "post", lambda *a, **k: response(200, {"access_token": "access_a_1"})
+    )
+    assert provider.refresh_norman_token_sync("mcp_a") == "access_a_1"
+    assert provider.token_mapping["mcp_refresh_a"] == "refresh_a_0"
+    with token_client(provider) as client:
+        assert refresh_request(client).status_code == 200
+
+
+def test_revoked_grant_returns_oauth_error_instead_of_500(provider, upstream, monkeypatch):
+    before = dict(provider.token_mapping)
+    monkeypatch.setattr(requests, "post", lambda *a, **k: response(400, {"error": "invalid_grant"}))
+    with token_client(provider) as client:
+        result = refresh_request(client)
+    assert result.status_code == 400
+    assert result.json()["error"] == "invalid_grant"
+    assert result.headers["cache-control"] == "no-store"
+    assert provider.token_mapping == before
+
+
+def test_missing_upstream_mapping_returns_oauth_error(provider, upstream):
+    del provider.token_mapping["mcp_refresh_a"]
+    with token_client(provider) as client:
+        result = refresh_request(client)
+    assert result.status_code == 400
+    assert result.json()["error"] == "invalid_grant"
+    assert upstream.seen == []
+
+
+@pytest.mark.parametrize("failure", ["timeout", "rate_limit", "upstream_5xx"])
+def test_transient_failure_preserves_credentials_for_retry(
+    provider, upstream, monkeypatch, failure
+):
+    before = dict(provider.token_mapping)
+
+    def failed_post(*args, **kwargs):
+        if failure == "timeout":
+            raise requests.Timeout("timeout with sensitive request context")
+        return response(429 if failure == "rate_limit" else 502, {"error": "unavailable"})
+
+    monkeypatch.setattr(requests, "post", failed_post)
+    with token_client(provider) as client:
+        result = refresh_request(client)
+        assert result.status_code == 503
+        assert result.headers["retry-after"] == "5"
+        assert "sensitive" not in result.text
+        assert provider.token_mapping == before
+        monkeypatch.setattr(requests, "post", upstream.post)
+        assert refresh_request(client).status_code == 200
+
+
+@pytest.mark.parametrize(
+    "body", [[], {}, {"access_token": 42}, {"access_token": "ok", "refresh_token": 42}]
+)
+def test_invalid_upstream_payload_never_overwrites_credentials(
+    provider, upstream, monkeypatch, body
+):
+    before = dict(provider.token_mapping)
+    monkeypatch.setattr(requests, "post", lambda *a, **k: response(200, body))
+    with token_client(provider) as client:
+        result = refresh_request(client)
+    assert result.status_code == 502
+    assert provider.token_mapping == before


### PR DESCRIPTION
## Problem

Transparent Norman token refresh rotated the upstream refresh token without updating the MCP client's refresh handle. A later client refresh reused the revoked token and could return HTTP 500. Client-initiated refresh also left older live MCP access tokens with stale upstream credentials.

This is a locally reproduced cause of authentication failures; it does not establish that every error in Claude Connector metrics has the same cause.

## Changes

- Synchronize both refresh paths across aliases sharing the exact same upstream refresh token, preserving the existing persisted state format.
- Serialize refreshes per upstream grant and run client refresh off the event loop. Accounts sharing a client ID remain isolated.
- Return OAuth `invalid_grant` for revoked/missing grants; preserve credentials and return retryable HTTP 503 for transient upstream failures.
- Validate upstream payloads before replacing stored credentials and avoid logging sensitive request/response data.

No changes to redirects, DCR, company-selection behavior, dependencies, or deployment configuration.

## Validation

- 112 tests passed with `.venv/bin/pytest -q --ignore=tests/test_basic.py`, including 14 new regression cases.
- Coverage includes both rotation orders, persistence/restart, concurrent refresh paths, account isolation, revoked grants, transient failures, and malformed payloads.
- Three core regression tests fail against the current `origin/main`, confirming the stale-token and HTTP 500 defects.
- New tests pass Black and Flake8; changed provider methods pass a focused Black check; `git diff --check` passes.
- Existing `tests/test_basic.py` cannot collect because it imports the removed `Config` symbol from `norman_mcp.server`; excluded without changing unrelated tests.

## Rollout limitation

Already-desynchronized sessions may need one reconnect after deployment. The fix deliberately does not infer missing grant relationships from a shared MCP client ID, which would risk mixing accounts. Refresh locks remain process-local, consistent with the existing node-local state model.

This PR has not been merged or deployed.
